### PR TITLE
Disable telemetry for sumneko lua lsp

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -332,6 +332,8 @@ require('lspconfig').sumneko_lua.setup {
         globals = { 'vim' },
       },
       workspace = { library = vim.api.nvim_get_runtime_file('', true) },
+      -- Do not send telemetry data containing a randomized but unique identifier
+      telemetry = { enable = false, },
     },
   },
 }


### PR DESCRIPTION
Based on existing recommended config in [lsp-config](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#sumneko_lua), this disables the telemetry for sumneko lua lsp.