### PR TITLE
improve startup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A starting point for neovim that is:
 
-* Small (~325 lines)
+* Small (~397 lines)
 * Single-file
 * Documented
 * Modular

--- a/init.lua
+++ b/init.lua
@@ -165,8 +165,12 @@ require('telescope').setup {
 pcall(require('telescope').load_extension, 'fzf')
 
 -- See `:help telescope.builtin`
-vim.keymap.set('n', '<leader>?', require('telescope.builtin').oldfiles, { desc = '[?] Find recently opened files' })
-vim.keymap.set('n', '<leader><space>', require('telescope.builtin').buffers, { desc = '[ ] Find existing buffers' })
+vim.keymap.set('n', '<leader>?', function()
+  require('telescope.builtin').oldfiles()
+end, { desc = '[?] Find recently opened files' })
+vim.keymap.set('n', '<leader><space>', function()
+  require('telescope.builtin').buffers()
+end, { desc = '[ ] Find existing buffers' })
 vim.keymap.set('n', '<leader>/', function()
   -- You can pass additional configuration to telescope to change theme, layout, etc.
   require('telescope.builtin').current_buffer_fuzzy_find(require('telescope.themes').get_dropdown {
@@ -175,11 +179,21 @@ vim.keymap.set('n', '<leader>/', function()
   })
 end, { desc = '[/] Fuzzily search in current buffer]' })
 
-vim.keymap.set('n', '<leader>sf', require('telescope.builtin').find_files, { desc = '[S]earch [F]iles' })
-vim.keymap.set('n', '<leader>sh', require('telescope.builtin').help_tags, { desc = '[S]earch [H]elp' })
-vim.keymap.set('n', '<leader>sw', require('telescope.builtin').grep_string, { desc = '[S]earch current [W]ord' })
-vim.keymap.set('n', '<leader>sg', require('telescope.builtin').live_grep, { desc = '[S]earch by [G]rep' })
-vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { desc = '[S]earch [D]iagnostics' })
+vim.keymap.set('n', '<leader>sf', function()
+  require('telescope.builtin').find_files()
+end, { desc = '[S]earch [F]iles' })
+vim.keymap.set('n', '<leader>sh', function()
+  require('telescope.builtin').help_tags()
+end, { desc = '[S]earch [H]elp' })
+vim.keymap.set('n', '<leader>sw', function()
+  require('telescope.builtin').grep_string()
+end, { desc = '[S]earch current [W]ord' })
+vim.keymap.set('n', '<leader>sg', function()
+  require('telescope.builtin').live_grep()
+end, { desc = '[S]earch by [G]rep' })
+vim.keymap.set('n', '<leader>sd', function()
+  require('telescope.builtin').diagnostics()
+end, { desc = '[S]earch [D]iagnostics' })
 
 -- [[ Configure Treesitter ]]
 -- See `:help nvim-treesitter`


### PR DESCRIPTION
`keymap.set` docs:
```
                Note that in a mapping like:  

                    vim.keymap.set('n', 'asdf', require('jkl').my_fun)
 

                the `require('jkl')` gets evaluated during this call in order to access the
                function. If you want to avoid this cost at startup you can
                wrap it in a function, for example:  

                    vim.keymap.set('n', 'asdf', function() return require('jkl').my_fun() end)
```