### PR TITLE
Don't pass args to vim.lsp.buf.format/formatting in "Format"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -289,7 +289,13 @@ local on_attach = function(_, bufnr)
   end, '[W]orkspace [L]ist Folders')
 
   -- Create a command `:Format` local to the LSP buffer
-  vim.api.nvim_buf_create_user_command(bufnr, 'Format', vim.lsp.buf.format or vim.lsp.buf.formatting, { desc = 'Format current buffer with LSP' })
+  vim.api.nvim_buf_create_user_command(bufnr, 'Format', function(_)
+    if vim.lsp.buf.format then
+      vim.lsp.buf.format()
+    elseif vim.lsp.buf.formatting then
+      vim.lsp.buf.formatting()
+    end
+  end, { desc = 'Format current buffer with LSP' })
 end
 
 -- nvim-cmp supports additional completion capabilities


### PR DESCRIPTION
Call `vim.lsp.buf.format/formatting` without any arguments in `Format`.

With rust-analyzer I was getting the error below in 0.7.x with `vim.lsp.buf.formatting`. Incorrect parameters were being used as `FormattingOptions` before.

```
rust_analyzer: -32602: Failed to deserialize textDocument/formatting: data did not match any variant of untagged enum FormattingProperty; {"textDocument":{"uri":"file:///tmp/hello/src/main.rs"},"options":{"bang":false,"fargs":[],"args":"","line1":1,"line2":1,"reg":"","mods":"","tabSize":4,"insertSpaces":true,"range":0,"count":-1}}
```