### PR TITLE
Added cpp to treesitter and ordered TS imports

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -185,7 +185,7 @@ vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { de
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = { 'lua', 'typescript', 'rust', 'go', 'python' },
+  ensure_installed = {'c', 'cpp', 'go', 'lua', 'python', 'rust', 'typescript'},
 
   highlight = { enable = true },
   indent = { enable = true },


### PR DESCRIPTION
We're adding the clangd language server on line 299 so it seemed sensible to add cpp to the treesitter languages. (I could also have added C as well/instead - please advise if you'd prefer C there instead or added as well. I'm guessing C would make more sense as that's the main language nvim is written in?)

I've also alphabetised that list of treesitter languages while I was at it just to make it look better. 