### PR TITLE
Add optional packer plugins hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,42 @@ Kickstart targets *only* the latest stable neovim release (0.7) and the nightly.
 This repo is meant to be used as a starting point for a user's own configuration; remove the things you don't use and add what you miss. This configuration serves as the reference configuration for the [lspconfig wiki](https://github.com/neovim/nvim-lspconfig/wiki).
 
 ### Installation
+
 * Backup your previous configuration
 * Copy and paste the kickstart.nvim `init.lua` into `$HOME/.config/nvim/init.lua`
 * start neovim (`nvim`) and run `:PackerInstall`, ignore any error message about missing plugins, `:PackerInstall` will fix that shortly.
 * restart neovim
+
+### Configuration
+
+You could directly modify the `init.lua` file with your personal customizations. This option is the most straightforward, but if you update your config from this repo, you may need to reapply your changes.
+
+An alternative approach is to create a separate `custom.plugins` module to register your own plugins. In addition, you can handle further customizations in a `after/plugin/defaults.lua` file. See the following examples for more information. Leveraging these files should make upgrading to a newer version of this repo easier. 
+
+#### Example `plugins.lua`
+
+The following is an example of a `plugins.lua` file (located at `$HOME/.config/nvim/lua/custom/plugins.lua`) where you can register you own plugins. 
+
+```lua
+return function(use)
+  use({
+    "folke/which-key.nvim",
+      config = function()
+        require("which-key").setup({})
+      end
+  })
+end
+```
+
+#### Example `defaults.lua`
+
+The following is an example `defaults.lua` file (localed at `$HOME/.config/nvim/after/plugin/defaults.lua`) where you can define your own options, keymaps, autogroups, and more.
+
+```lua
+vim.opt.relativenumber = true
+
+vim.keymap.set('n', '<leader>sr', require('telescope.builtin').resume, { desc = '[S]earch [R]esume' })
+```
 
 ### Contribution
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ This repo is meant to be used as a starting point for a user's own configuration
 
 You could directly modify the `init.lua` file with your personal customizations. This option is the most straightforward, but if you update your config from this repo, you may need to reapply your changes.
 
-An alternative approach is to create a separate `custom.plugins` module to register your own plugins. In addition, you can handle further customizations in a `after/plugin/defaults.lua` file. See the following examples for more information. Leveraging these files should make upgrading to a newer version of this repo easier. 
+An alternative approach is to create a separate `custom.plugins` module to register your own plugins. In addition, you can handle further customizations in the `/after/plugin/` directory (see `:help load-plugins`). See the following examples for more information. Leveraging this technique should make upgrading to a newer version of this repo easier. 
 
 #### Example `plugins.lua`
 
-The following is an example of a `plugins.lua` file (located at `$HOME/.config/nvim/lua/custom/plugins.lua`) where you can register you own plugins. 
+The following is an example of a `plugins.lua` module (located at `$HOME/.config/nvim/lua/custom/plugins.lua`) where you can register your own plugins. 
 
 ```lua
 return function(use)
@@ -41,7 +41,7 @@ end
 
 #### Example `defaults.lua`
 
-The following is an example `defaults.lua` file (localed at `$HOME/.config/nvim/after/plugin/defaults.lua`) where you can define your own options, keymaps, autogroups, and more.
+For further customizations, you can add a file in the `/after/plugin/` folder (see `:help load-plugins`) to include your own options, keymaps, autogroups, and more. The following is an example `defaults.lua` file (located at `$HOME/.config/nvim/after/plugin/defaults.lua`).
 
 ```lua
 vim.opt.relativenumber = true

--- a/init.lua
+++ b/init.lua
@@ -32,6 +32,10 @@ require('packer').startup(function(use)
   -- Fuzzy Finder Algorithm which requires local dependencies to be built. Only load if `make` is available
   use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'make', cond = vim.fn.executable "make" == 1 }
 
+  -- Add custom plugins to packer from a /nvim/lua/custom/plugins.lua module
+  local has_plugins, plugins = pcall(require, "custom.plugins")
+  if has_plugins then plugins.setup(use) end
+
   if is_bootstrap then
     require('packer').sync()
   end

--- a/init.lua
+++ b/init.lua
@@ -32,9 +32,9 @@ require('packer').startup(function(use)
   -- Fuzzy Finder Algorithm which requires local dependencies to be built. Only load if `make` is available
   use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'make', cond = vim.fn.executable "make" == 1 }
 
-  -- Add custom plugins to packer from a /nvim/lua/custom/plugins.lua module
+  -- Add custom plugins to packer from /nvim/lua/custom/plugins.lua
   local has_plugins, plugins = pcall(require, "custom.plugins")
-  if has_plugins then plugins.setup(use) end
+  if has_plugins then plugins(use) end
 
   if is_bootstrap then
     require('packer').sync()


### PR DESCRIPTION
As an experiment, I've gone "neovim config bankruptcy" and have been using `kickstart.nvim` for the last two weeks. I added a few custom plugins to packer and several custom options and keymaps.

Then I noticed how active this repo is (which is awesome) and I wanted to upgrade my local version, but my additions were intermingled in the base `init.lua` file. 

So, I pulled out my custom options and keymaps into a `nvim/after/plugin/defaults.lua` file (which worked out great), but the issue I was encountering was figuring out how to pull out the definition of my custom plugins, hence this PR. 

With the two new lines included in this PR it enables the user to safely reset their version of `init.lua` and let any of their customizations be in a `nvim/after/plugin/defaults.lua` file and optionally a `nvim/lua/custom/plugins.lua` module.

The optional plugins module could look like...

```lua
-- lua/custom/plugins.lua
local plugins = {}

function plugins.setup(use)
  use { "nvim-telescope/telescope-file-browser.nvim" }

  use({
    "folke/which-key.nvim",
    config = function()
      require("which-key").setup({})
    end,
  })
end

return plugins
```

> NOTE: As an aside, it is great that you all have added the `desc` to the mappings you've included, which works great with `which-key.nvim` making it easier for a new user to get their bearings on the possible unfamiliar keymaps.

You all have done a great job of keeping things simple, fresh, and updated as neovim and plugin APIs shift. For that reason, it seems like a nice feature to let the user update their version (using something like `wget https://github.com/nvim-lua/kickstart.nvim/blob/master/init.lua -O ~/.config/nvim/init.lua`) without losing their custom configurations.

Thanks for your consideration. 
