### PR TITLE
Fix nvim-treesitter-textobjects install warning

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -9,22 +9,22 @@ end
 
 -- stylua: ignore start
 require('packer').startup(function(use)
-  use 'wbthomason/packer.nvim'                                              -- Package manager
-  use 'tpope/vim-fugitive'                                                  -- Git commands in nvim
-  use 'tpope/vim-rhubarb'                                                   -- Fugitive-companion to interact with github
-  use { 'lewis6991/gitsigns.nvim', requires = { 'nvim-lua/plenary.nvim' } } -- Add git related info in the signs columns and popups
-  use 'numToStr/Comment.nvim'                                               -- "gc" to comment visual regions/lines
-  use 'nvim-treesitter/nvim-treesitter'                                     -- Highlight, edit, and navigate code
-  use 'nvim-treesitter/nvim-treesitter-textobjects'                         -- Additional textobjects for treesitter
-  use 'neovim/nvim-lspconfig'                                               -- Collection of configurations for built-in LSP client
-  use 'williamboman/mason.nvim'                                             -- Manage external editor tooling i.e LSP servers
-  use 'williamboman/mason-lspconfig.nvim'                                   -- Automatically install language servers to stdpath
-  use { 'hrsh7th/nvim-cmp', requires = { 'hrsh7th/cmp-nvim-lsp' } }         -- Autocompletion
-  use { 'L3MON4D3/LuaSnip', requires = { 'saadparwaiz1/cmp_luasnip' } }     -- Snippet Engine and Snippet Expansion
-  use 'mjlbach/onedark.nvim'                                                -- Theme inspired by Atom
-  use 'nvim-lualine/lualine.nvim'                                           -- Fancier statusline
-  use 'lukas-reineke/indent-blankline.nvim'                                 -- Add indentation guides even on blank lines
-  use 'tpope/vim-sleuth'                                                    -- Detect tabstop and shiftwidth automatically
+  use 'wbthomason/packer.nvim'                                                         -- Package manager
+  use 'tpope/vim-fugitive'                                                             -- Git commands in nvim
+  use 'tpope/vim-rhubarb'                                                              -- Fugitive-companion to interact with github
+  use { 'lewis6991/gitsigns.nvim', requires = { 'nvim-lua/plenary.nvim' } }            -- Add git related info in the signs columns and popups
+  use 'numToStr/Comment.nvim'                                                          -- "gc" to comment visual regions/lines
+  use 'nvim-treesitter/nvim-treesitter'                                                -- Highlight, edit, and navigate code
+  use { 'nvim-treesitter/nvim-treesitter-textobjects', after = { 'nvim-treesitter' } } -- Additional textobjects for treesitter
+  use 'neovim/nvim-lspconfig'                                                          -- Collection of configurations for built-in LSP client
+  use 'williamboman/mason.nvim'                                                        -- Manage external editor tooling i.e LSP servers
+  use 'williamboman/mason-lspconfig.nvim'                                              -- Automatically install language servers to stdpath
+  use { 'hrsh7th/nvim-cmp', requires = { 'hrsh7th/cmp-nvim-lsp' } }                    -- Autocompletion
+  use { 'L3MON4D3/LuaSnip', requires = { 'saadparwaiz1/cmp_luasnip' } }                -- Snippet Engine and Snippet Expansion
+  use 'mjlbach/onedark.nvim'                                                           -- Theme inspired by Atom
+  use 'nvim-lualine/lualine.nvim'                                                      -- Fancier statusline
+  use 'lukas-reineke/indent-blankline.nvim'                                            -- Add indentation guides even on blank lines
+  use 'tpope/vim-sleuth'                                                               -- Detect tabstop and shiftwidth automatically
 
   -- Fuzzy Finder (files, lsp, etc)
   use { 'nvim-telescope/telescope.nvim', branch = '0.1.x', requires = { 'nvim-lua/plenary.nvim' } }
@@ -188,7 +188,7 @@ vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { de
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = {'c', 'cpp', 'go', 'lua', 'python', 'rust', 'typescript'},
+  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'typescript' },
 
   highlight = { enable = true },
   indent = { enable = true },
@@ -345,7 +345,7 @@ require('lspconfig').sumneko_lua.setup {
       },
       workspace = { library = vim.api.nvim_get_runtime_file('', true) },
       -- Do not send telemetry data containing a randomized but unique identifier
-      telemetry = { enable = false, },
+      telemetry = { enable = false },
     },
   },
 }


### PR DESCRIPTION
Should fix the following warning when doing a fresh install.
```
==================================
    Plugins are being installed
    Wait until Packer completes,
       then restart nvim
==================================
[packer.nvim] [ERROR 13:30:14] async.lua:20: Error in coroutine: ...ack/packer/start/packer.nvim/lua/packer/plugin_utils.lua:204: Vim(lua):E5108: Error executing lua ...eesitter-textobjects/lua/nvim-treesitter-textobjects.lua:1: module 'nvim-treesitter.query' not found:
^Ino field package.preload['nvim-treesitter.query']
^Ino file './nvim-treesitter/query.lua'
^Ino file '/usr/share/luajit-2.1.0-beta3/nvim-treesitter/query.lua'
^Ino file '/usr/local/share/lua/5.1/nvim-treesitter/query.lua'
^Ino file '/usr/local/share/lua/5.1/nvim-treesitter/query/init.lua'
^Ino file '/usr/share/lua/5.1/nvim-treesitter/query.lua'
^Ino file '/usr/share/lua/5.1/nvim-treesitter/query/init.lua'
^Ino file './nvim-treesitter/query.so'
^Ino file '/usr/local/lib/lua/5.1/nvim-treesitter/query.so'
^Ino file '/usr/lib/lua/5.1/nvim-treesitter/query.so'
^Ino file '/usr/local/lib/lua/5.1/loadall.so'
^Ino file './nvim-treesitter.so'
^Ino file '/usr/local/lib/lua/5.1/nvim-treesitter.so'
^Ino file '/usr/lib/lua/5.1/nvim-treesitter.so'
^Ino file '/usr/local/lib/lua/5.1/loadall.so'
stack traceback:
^I[C]: in function 'require'
^I...eesitter-textobjects/lua/nvim-treesitter-textobjects.lua:1: in main chunk
^I[C]: in function 'require'
^I[string ":lua"]:1: in main chunk
^I[C]: in function 'resume'
^I.../site/pack/packer/start/packer.nvim/lua/packer/async.lua:12: in function <.../site/pack/packer/start/packer.nvim/lua/packer/async.lua:11>
```