### PR TITLE
replace cmp_nvim_lsp deprecated methods

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -302,7 +302,7 @@ local on_attach = function(_, bufnr)
 end
 
 -- nvim-cmp supports additional completion capabilities
-local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
 -- Setup mason so it can manage external tooling
 require('mason').setup()


### PR DESCRIPTION
`cmp_nvim_lsp.update_capabilities` is deprecated and will be removed in cmp-nvim-lsp 1.0.0, use `cmp_nvim_lsp.default_capabilities` instead.