### PR TITLE
Update deprecated nvim_cmp capabilities

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -302,7 +302,7 @@ local on_attach = function(_, bufnr)
 end
 
 -- nvim-cmp supports additional completion capabilities
-local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
+local capabilities = require('cmp_nvim_lsp').default_capabilities(vim.lsp.protocol.make_client_capabilities())
 
 -- Setup mason so it can manage external tooling
 require('mason').setup()


### PR DESCRIPTION
Solves this warning message 
```
cmp_nvim_lsp.update_capabilities is deprecated, use cmp_nvim_lsp.default_capabilities instead. See :h deprecated
This function will be removed in cmp-nvim-lsp version 1.0.0
stack traceback:
        ...pack/packer/start/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:68: in function 'update_capabilities'
       ~/.config/nvim/init.lua:305: in main chunk
```