### PR TITLE
Enable parameter text objects

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -235,6 +235,8 @@ require('nvim-treesitter.configs').setup {
       lookahead = true, -- Automatically jump forward to textobj, similar to targets.vim
       keymaps = {
         -- You can use the capture groups defined in textobjects.scm
+        ['aa'] = '@parameter.outer',
+        ['ia'] = '@parameter.inner',
         ['af'] = '@function.outer',
         ['if'] = '@function.inner',
         ['ac'] = '@class.outer',


### PR DESCRIPTION
This seems like a natural addition. In classic Vim, I used to use https://github.com/b4winckler/vim-angry for this.