### PR TITLE
Fix minor spelling mistake, add `packer_compiled.lua` to .`gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tags
 test.sh
 .luarc.json
 nvim
+packer_compiled.lua

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk --no-cache add \
     pkgconf \
     unzip
 
-# Build neovim (and use it as an example codebase
+# Build neovim (and use it) as an example codebase
 RUN git clone https://github.com/neovim/neovim.git
 
 ARG VERSION=master


### PR DESCRIPTION
Fixes a minor spelling mistake, adds `packer_compiled.lua` to .`gitignore` .