### PR TITLE
fix: don't check third party for Lua LSP

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -381,7 +381,7 @@ require('lspconfig').sumneko_lua.setup {
       },
       workspace = {
         library = vim.api.nvim_get_runtime_file('', true),
-        checkcheckThirdParty = false,
+        checkThirdParty = false,
       },
       -- Do not send telemetry data containing a randomized but unique identifier
       telemetry = { enable = false },

--- a/init.lua
+++ b/init.lua
@@ -379,7 +379,10 @@ require('lspconfig').sumneko_lua.setup {
       diagnostics = {
         globals = { 'vim' },
       },
-      workspace = { library = vim.api.nvim_get_runtime_file('', true) },
+      workspace = {
+        library = vim.api.nvim_get_runtime_file('', true),
+        checkcheckThirdParty = false,
+      },
       -- Do not send telemetry data containing a randomized but unique identifier
       telemetry = { enable = false },
     },


### PR DESCRIPTION
Every time I open a Lua file to configure `nvim`, I have this annoying prompt:

```
Do you need to configure your work environment as `luassert`?

Request Actions:
1. Apply and modify settings
2. Apply but do not modify settings
3. Don't show again
Type number and <Enter> or click with the mouse (q or empty cancels):
```

I'm not familiar with `sumneko_lua` but [a similar issue was reported here](https://github.com/neovim/nvim-lspconfig/issues/1700) and [this fix was suggested](https://github.com/neovim/nvim-lspconfig/issues/1700#issuecomment-1033127328).

It works and makes the prompt disappear. I'm proposing this fix to you in case you're interested.