### PR TITLE
Do not override treesitter lua highlighting with sumneko lua highlighting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -382,6 +382,8 @@ require('lspconfig').sumneko_lua.setup {
       workspace = { library = vim.api.nvim_get_runtime_file('', true) },
       -- Do not send telemetry data containing a randomized but unique identifier
       telemetry = { enable = false },
+      -- Do not override treesitter lua highlighting with sumneko lua highlighting
+      semantic = { enable = false },
     },
   },
 }


### PR DESCRIPTION
I noticed that when opening a lua file, the highlighting initially looks really nice. (Thanks treesitter!) But then once sumneko_lua is done initializing, the highlighting changes slightly (specifically, parent fields turn back to white). This is because sumneko overrides treesitter's highlighting with its own. So this PR disables the sumneko highlighting so we can keep the pretty treesitter one.

This is the field:
https://github.com/sumneko/lua-language-server/wiki/Settings#semanticenable

Signed-off-by: David Ward <dward@redhat.com>