### PR TITLE
Fix error on Windows when space in install path

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,7 +3,7 @@ local install_path = vim.fn.stdpath 'data' .. '/site/pack/packer/start/packer.nv
 local is_bootstrap = false
 if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
   is_bootstrap = true
-  vim.fn.execute('!git clone https://github.com/wbthomason/packer.nvim ' .. install_path)
+  vim.fn.system({'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path})
   vim.cmd [[packadd packer.nvim]]
 end
 


### PR DESCRIPTION
Fixes #55. When there is a space in the install path, Packer is not cloned properly on startup. This change resolves the issue. Tested on Windows 11 with Neovim v0.8.1

`--depth 1` is borrowed from the original Packer documentation at https://github.com/wbthomason/packer.nvim#bootstrapping. This option only clones the most recent commit, which is all that is necessary for the initial install.