### PR TITLE
Adding Windows CMake documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ This repo is meant to be used as a starting point for a user's own configuration
 
 If there are languages that you don't want to use, remove their configuration and notes from your `init.lua` after copy and pasting (for example, in the mason configuration).
 
+### Windows Installation
+
+Installation may require installing build tools, and updating the run command for `telescope-fzf-native`
+
+See `telescope-fzf-native` documention for [more details](https://github.com/nvim-telescope/telescope-fzf-native.nvim#installation)
+
+This requires:
+
+- Install CMake, and the Microsoft C++ Build Tools on Windows
+
+```lua
+use {'nvim-telescope/telescope-fzf-native.nvim', run = 'cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build' }
+```
+
 ### Configuration
 
 You could directly modify the `init.lua` file with your personal customizations. This option is the most straightforward, but if you update your config from this repo, you may need to reapply your changes.


### PR DESCRIPTION
Adds an update to the README for installing `telescope-fzf-native` under windows. Also links to the relevant section in the `telescope-fzf-native` documentation regarding build requirements.