### PR TITLE
Prevent multiple language servers from being spawned after every file save of init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -87,7 +87,7 @@ end
 -- Automatically source and re-compile packer whenever you save this init.lua
 local packer_group = vim.api.nvim_create_augroup('Packer', { clear = true })
 vim.api.nvim_create_autocmd('BufWritePost', {
-  command = 'source <afile> | PackerCompile',
+  command = 'source <afile> | LspStop | LspStart | PackerCompile',
   group = packer_group,
   pattern = vim.fn.expand '$MYVIMRC',
 })

--- a/init.lua
+++ b/init.lua
@@ -87,7 +87,7 @@ end
 -- Automatically source and re-compile packer whenever you save this init.lua
 local packer_group = vim.api.nvim_create_augroup('Packer', { clear = true })
 vim.api.nvim_create_autocmd('BufWritePost', {
-  command = 'source <afile> | LspStop | LspStart | PackerCompile',
+  command = 'source <afile> | silent! LspStop | silent! LspStart | PackerCompile',
   group = packer_group,
   pattern = vim.fn.expand '$MYVIMRC',
 })


### PR DESCRIPTION
Fixed #89. 
Prevent multiple language servers from being spawned after every save of init.lua, which eventually leads to high RAM usage and system freeze. 
