### PR TITLE
Fix typo in the description of fuzzy search

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -209,7 +209,7 @@ vim.keymap.set('n', '<leader>/', function()
     winblend = 10,
     previewer = false,
   })
-end, { desc = '[/] Fuzzily search in current buffer]' })
+end, { desc = '[/] Fuzzily search in current buffer' })
 
 vim.keymap.set('n', '<leader>sf', require('telescope.builtin').find_files, { desc = '[S]earch [F]iles' })
 vim.keymap.set('n', '<leader>sh', require('telescope.builtin').help_tags, { desc = '[S]earch [H]elp' })


### PR DESCRIPTION
Remove a trailing ']' in the description of the fuzzy search keymap for telescope