### PR TITLE
luasnip: add region check on InsertEnter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -385,6 +385,10 @@ require('fidget').setup()
 local cmp = require 'cmp'
 local luasnip = require 'luasnip'
 
+luasnip.config.set_config {
+  region_check_events = 'InsertEnter'
+}
+
 cmp.setup {
   snippet = {
     expand = function(args)


### PR DESCRIPTION
Closes #109 

Motivation: new users won't know how to properly use luasnip, and will struggle with tab making the cursor completely jump to somewhere else. I feel like this is a sane default.

Before: 
![before](https://user-images.githubusercontent.com/9609090/210677347-7ca6cb4c-dc7b-4da4-b064-5ed5adf30429.gif)

After:
![after](https://user-images.githubusercontent.com/9609090/210677357-82466224-a9eb-40d5-897b-61de7270650b.gif)
