### PR TITLE
Configure packer_compiled.lua to be stored on XDG_DATA_DIRS

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,15 +12,15 @@ local status_ok, packer = pcall(require, "packer")
 if not status_ok then
   return
 end
-local status_util_ok, util = pcall(require, "packer.util")
+local status_util_ok, packer_util = pcall(require, "packer.util")
 if not status_util_ok then
   return
 end
 
 -- Have packer use a popup window
 packer.init({
-  package_root = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
-  compile_path = util.join_paths(vim.fn.stdpath('data'), 'site', 'plugin', 'packer_compiled.lua'),
+  package_root = packer_util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
+  compile_path = packer_util.join_paths(vim.fn.stdpath('data'), 'site', 'plugin', 'packer_compiled.lua'),
 })
 
 packer.startup(function(use)

--- a/init.lua
+++ b/init.lua
@@ -12,8 +12,8 @@ local status_ok, packer = pcall(require, "packer")
 if not status_ok then
   return
 end
-local status_util_ok, packer_util = pcall(require, "packer.util")
-if not status_util_ok then
+local status_packer_util_ok, packer_util = pcall(require, "packer.util")
+if not status_packer_util_ok then
   return
 end
 

--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,23 @@ if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
   vim.cmd [[packadd packer.nvim]]
 end
 
-require('packer').startup(function(use)
+-- Use a protected call so we don't error out on first use
+local status_ok, packer = pcall(require, "packer")
+if not status_ok then
+  return
+end
+local status_util_ok, util = pcall(require, "packer.util")
+if not status_util_ok then
+  return
+end
+
+-- Have packer use a popup window
+packer.init({
+  package_root = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
+  compile_path = util.join_paths(vim.fn.stdpath('data'), 'site', 'plugin', 'packer_compiled.lua'),
+})
+
+packer.startup(function(use)
   -- Package manager
   use 'wbthomason/packer.nvim'
 


### PR DESCRIPTION
The `packer_compiled.lua` use a lot of values that only works on the host
where the file was compiled.

Put the compiled file on XDG_DATA_DIRS make easier use ~/.config/nvim to both
on Linux and Macos.
