### PR TITLE
add custom config call, post config, pre keymap/plugin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ return function(use)
 end
 ```
 
+#### Example `config.lua`
+
+Customizing initialization behavior (beyond plugin configuration discussed above) can occur in two places -- before, and after, base configuration and plugin configuration. If you need to update something before kickstart loads, e.g. setting the `mapleader`, this can be done by adding a `config.lua` file (located at `$HOME/.config/nvim/lua/custom/config.lua`).
+
+```lua
+return function()
+  -- set the leaders
+  vim.g.mapleader = ';'
+  vim.g.localmapleader = ' '
+end
+```
+
 #### Example `defaults.lua`
 
 For further customizations, you can add a file in the `/after/plugin/` folder (see `:help load-plugins`) to include your own options, keymaps, autogroups, and more. The following is an example `defaults.lua` file (located at `$HOME/.config/nvim/after/plugin/defaults.lua`).

--- a/init.lua
+++ b/init.lua
@@ -132,6 +132,12 @@ vim.o.completeopt = 'menuone,noselect'
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
 
+-- Add custom config before keymaps and plugin configs
+local has_config, config = pcall(require, 'custom.config')
+if has_config then
+  config()
+end
+
 -- Keymaps for better default experience
 -- See `:help vim.keymap.set()`
 vim.keymap.set({ 'n', 'v' }, '<Space>', '<Nop>', { silent = true })


### PR DESCRIPTION
add flexible configuration (overrides) while keeping vanilla init.lua, by
allowing a `custom.config` call to be made after default leader and base
options, but before keymaps are setup, and later plugins setup.

See also https://github.com/nvim-lua/kickstart.nvim/issues/160

Still TODO -- update docs to reflect the change, but putting this here for fast feedback.