### PR TITLE
Use lua_ls as Lua Language Server

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -343,7 +343,7 @@ local servers = {
   -- rust_analyzer = {},
   -- tsserver = {},
 
-  sumneko_lua = {
+  lua_ls = {
     Lua = {
       workspace = { checkThirdParty = false },
       telemetry = { enable = false },


### PR DESCRIPTION
sumneko_lua is deprecated. Causing warning like:
```
mason-lspconfig.nvim] Server "sumneko_lua" is not a valid entry in ensure_installed. 
Make sure to only provide lspconfig server names
```
While the language server is not loaded. 
Fix this warning by using lua_ls instead of sumneko_lua.
#171