### PR TITLE
feat: Enable relative line number by default

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -198,6 +198,9 @@ vim.o.hlsearch = false
 -- Make line numbers default
 vim.wo.number = true
 
+-- Enable relative line number
+vim.o.relativenumber = true
+
 -- Enable mouse mode
 vim.o.mouse = 'a'
 


### PR DESCRIPTION
Enable relative line number by default

I think it might be very useful to have this turned on by default. 
It's one of the greatest feature from vim IMO- (as a beginner) 
being able to jump to whatever line by just looking at the relative line numbers, and then "7j" / "12k" / etc.