### PR TITLE
feat(docker): add simple config for trying or testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git*
+Dockerfile
+.dockerignore
+LICENSE.md
+README.md
+doc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM anatolelucet/neovim:nightly
+
+WORKDIR /root/.config/nvim
+
+# Install dependencies
+RUN apk add --update \
+    bash \
+    curl \
+    wget \
+    gzip \
+    unzip \
+    git \
+    npm \
+    alpine-sdk \
+    openssh-client \
+    python3 \
+    cargo \
+    ripgrep \
+    fd
+
+# Copy files
+RUN mkdir -p /root/.config/nvim
+COPY . /root/.config/nvim
+
+# Install nvim plugins and lsp servers
+RUN nvim --headless "+Lazy! install" +"MasonInstall pyright" +qa
+


### PR DESCRIPTION
I'm proposing a simple Docker blueprint for trying and testing the `kickstart.nvim` configuration. I believe it would be nice for people who wants to try the kickstart configuration, but do not want to mess with their machines or with their existing Neovim configurations. With the proposed container approach, it would be possible to enter a working `kickstart.nvim` demo by running the following: 

```sh
git clone https://github.com/nvim-lua/kickstart.nvim.git \
    && cd kickstart.nvim \
    && docker build -t kickstart . \
    && docker run -it --rm kickstart
```

