### PR TITLE
docs: add comment about WSL clipboarding

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -203,6 +203,7 @@ vim.o.mouse = 'a'
 
 -- Sync clipboard between OS and Neovim.
 --  Remove this option if you want your OS clipboard to remain independent.
+--  If you are on WSL2, you should remove this line or nvim may hang on paste
 --  See `:help 'clipboard'`
 vim.o.clipboard = 'unnamedplus'
 


### PR DESCRIPTION
Through much troubleshooting, this line was the source of my hanging issues on WSL, which makes sense since there's more layers interacting across threads. I've been testing with this disabled for 2 days now and it's never hung since, after a day of hanging pretty often on `p`