### PR TITLE
add built-in support for custom options, keybindings and `vim` commands

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -230,6 +230,9 @@ vim.o.completeopt = 'menuone,noselect'
 -- NOTE: You should make sure your terminal supports this
 vim.o.termguicolors = true
 
+-- NOTE: you can add any custom options in the `lua/custom/options.lua`
+-- file to avoid any conflict with this file if you're interested in keeping
+-- up-to-date with whatever is in the kickstart repo.
 pcall(require, 'custom/options')
 
 -- [[ Basic Keymaps ]]
@@ -242,6 +245,9 @@ vim.keymap.set({ 'n', 'v' }, '<Space>', '<Nop>', { silent = true })
 vim.keymap.set('n', 'k', "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
 vim.keymap.set('n', 'j', "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
 
+-- NOTE: you can add any custom keybinding in the `lua/custom/keybindings.lua`
+-- file to avoid any conflict with this file if you're interested in keeping
+-- up-to-date with whatever is in the kickstart repo.
 pcall(require, 'custom/keybindings')
 
 -- [[ Highlight on yank ]]
@@ -500,4 +506,7 @@ cmp.setup {
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et
 
+-- NOTE: you can add any custom `vim` command in the `lua/custom/commands.lua`
+-- file to avoid any conflict with this file if you're interested in keeping
+-- up-to-date with whatever is in the kickstart repo.
 pcall(require, 'custom/commands')

--- a/init.lua
+++ b/init.lua
@@ -230,7 +230,7 @@ vim.o.completeopt = 'menuone,noselect'
 -- NOTE: You should make sure your terminal supports this
 vim.o.termguicolors = true
 
-require('custom/options')
+pcall(require, 'custom/options')
 
 -- [[ Basic Keymaps ]]
 
@@ -242,7 +242,7 @@ vim.keymap.set({ 'n', 'v' }, '<Space>', '<Nop>', { silent = true })
 vim.keymap.set('n', 'k', "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
 vim.keymap.set('n', 'j', "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
 
-require('custom/keybindings')
+pcall(require, 'custom/keybindings')
 
 -- [[ Highlight on yank ]]
 -- See `:help vim.highlight.on_yank()`
@@ -500,4 +500,4 @@ cmp.setup {
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et
 
-require('custom/commands')
+pcall(require, 'custom/commands')

--- a/init.lua
+++ b/init.lua
@@ -244,7 +244,7 @@ vim.keymap.set({ 'n', 'v' }, '<Space>', '<Nop>', { silent = true })
 vim.keymap.set('n', 'k', "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
 vim.keymap.set('n', 'j', "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
 
--- NOTE: you can add any custom keybinding in the `lua/custom/keybindings.lua`
+-- NOTE: you can add any custom keybinding in the `lua/custom/map.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
 
@@ -504,9 +504,9 @@ cmp.setup {
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et
 
--- NOTE: you can add any custom `vim` command in the `lua/custom/commands.lua`
+-- NOTE: you can add any additional custom `vim` config in the `lua/custom/after.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
 pcall(require, 'custom/options')
-pcall(require, 'custom/keybindings')
-pcall(require, 'custom/commands')
+pcall(require, 'custom/map')
+pcall(require, 'custom/after')

--- a/init.lua
+++ b/init.lua
@@ -86,6 +86,7 @@ vim.o.termguicolors = true
 -- NOTE: you can add any custom options in the `lua/custom/options.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
+pcall(require, 'custom/options')
 
 -- Install package manager
 --    https://github.com/folke/lazy.nvim
@@ -247,6 +248,7 @@ vim.keymap.set('n', 'j', "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = tr
 -- NOTE: you can add any custom keybinding in the `lua/custom/map.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
+pcall(require, 'custom/map')
 
 -- [[ Highlight on yank ]]
 -- See `:help vim.highlight.on_yank()`
@@ -507,6 +509,4 @@ cmp.setup {
 -- NOTE: you can add any additional custom `vim` config in the `lua/custom/after.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
-pcall(require, 'custom/options')
-pcall(require, 'custom/map')
 pcall(require, 'custom/after')

--- a/init.lua
+++ b/init.lua
@@ -42,6 +42,51 @@ P.S. You can delete this when you're done too. It's your config now :)
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
 
+-- [[ Setting options ]]
+-- See `:help vim.o`
+
+-- Set highlight on search
+vim.o.hlsearch = false
+
+-- Make line numbers default
+vim.wo.number = true
+
+-- Enable mouse mode
+vim.o.mouse = 'a'
+
+-- Sync clipboard between OS and Neovim.
+--  Remove this option if you want your OS clipboard to remain independent.
+--  See `:help 'clipboard'`
+vim.o.clipboard = 'unnamedplus'
+
+-- Enable break indent
+vim.o.breakindent = true
+
+-- Save undo history
+vim.o.undofile = true
+
+-- Case insensitive searching UNLESS /C or capital in search
+vim.o.ignorecase = true
+vim.o.smartcase = true
+
+-- Keep signcolumn on by default
+vim.wo.signcolumn = 'yes'
+
+-- Decrease update time
+vim.o.updatetime = 250
+vim.o.timeout = true
+vim.o.timeoutlen = 300
+
+-- Set completeopt to have a better completion experience
+vim.o.completeopt = 'menuone,noselect'
+
+-- NOTE: You should make sure your terminal supports this
+vim.o.termguicolors = true
+
+-- NOTE: you can add any custom options in the `lua/custom/options.lua`
+-- file to avoid any conflict with this file if you're interested in keeping
+-- up-to-date with whatever is in the kickstart repo.
+
 -- Install package manager
 --    https://github.com/folke/lazy.nvim
 --    `:help lazy.nvim.txt` for more info
@@ -188,51 +233,6 @@ require('lazy').setup({
   --    to get rid of the warning telling you that there are not plugins in `lua/custom/plugins/`.
   { import = 'custom.plugins' },
 }, {})
-
--- [[ Setting options ]]
--- See `:help vim.o`
-
--- Set highlight on search
-vim.o.hlsearch = false
-
--- Make line numbers default
-vim.wo.number = true
-
--- Enable mouse mode
-vim.o.mouse = 'a'
-
--- Sync clipboard between OS and Neovim.
---  Remove this option if you want your OS clipboard to remain independent.
---  See `:help 'clipboard'`
-vim.o.clipboard = 'unnamedplus'
-
--- Enable break indent
-vim.o.breakindent = true
-
--- Save undo history
-vim.o.undofile = true
-
--- Case insensitive searching UNLESS /C or capital in search
-vim.o.ignorecase = true
-vim.o.smartcase = true
-
--- Keep signcolumn on by default
-vim.wo.signcolumn = 'yes'
-
--- Decrease update time
-vim.o.updatetime = 250
-vim.o.timeout = true
-vim.o.timeoutlen = 300
-
--- Set completeopt to have a better completion experience
-vim.o.completeopt = 'menuone,noselect'
-
--- NOTE: You should make sure your terminal supports this
-vim.o.termguicolors = true
-
--- NOTE: you can add any custom options in the `lua/custom/options.lua`
--- file to avoid any conflict with this file if you're interested in keeping
--- up-to-date with whatever is in the kickstart repo.
 
 -- [[ Basic Keymaps ]]
 

--- a/init.lua
+++ b/init.lua
@@ -233,7 +233,6 @@ vim.o.termguicolors = true
 -- NOTE: you can add any custom options in the `lua/custom/options.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
-pcall(require, 'custom/options')
 
 -- [[ Basic Keymaps ]]
 
@@ -248,7 +247,6 @@ vim.keymap.set('n', 'j', "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = tr
 -- NOTE: you can add any custom keybinding in the `lua/custom/keybindings.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
-pcall(require, 'custom/keybindings')
 
 -- [[ Highlight on yank ]]
 -- See `:help vim.highlight.on_yank()`
@@ -509,4 +507,6 @@ cmp.setup {
 -- NOTE: you can add any custom `vim` command in the `lua/custom/commands.lua`
 -- file to avoid any conflict with this file if you're interested in keeping
 -- up-to-date with whatever is in the kickstart repo.
+pcall(require, 'custom/options')
+pcall(require, 'custom/keybindings')
 pcall(require, 'custom/commands')

--- a/init.lua
+++ b/init.lua
@@ -230,6 +230,8 @@ vim.o.completeopt = 'menuone,noselect'
 -- NOTE: You should make sure your terminal supports this
 vim.o.termguicolors = true
 
+require('custom/options')
+
 -- [[ Basic Keymaps ]]
 
 -- Keymaps for better default experience
@@ -239,6 +241,8 @@ vim.keymap.set({ 'n', 'v' }, '<Space>', '<Nop>', { silent = true })
 -- Remap for dealing with word wrap
 vim.keymap.set('n', 'k', "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
 vim.keymap.set('n', 'j', "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
+
+require('custom/keybindings')
 
 -- [[ Highlight on yank ]]
 -- See `:help vim.highlight.on_yank()`
@@ -495,3 +499,5 @@ cmp.setup {
 
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et
+
+require('custom/commands')


### PR DESCRIPTION
hello there :wave: :yum: 

i really love this project and wanted to contribute a bit based on a "problem" i had :blush: 

## :exclamation: related issue
i've cloned my fork of the repo, removed the header as proposed and added the tokyonight theme in `lua/custom/plugins/tokyonight.lua` :ok_hand: 

now i wanted to add
- options
- keybindings
- post-startup commands

to my config.

### without modifying the `init.lua` file as much as possible!
as you say
> ... prevent any conflicts with this init.lua if you're interested in keeping
> up-to-date with whatever is in the kickstart repo.

in my personal config, i've added
- `lua/custom/options.lua` with things like
```lua
vim.opt.relativenumber = true
```
- `lua/custom/map.lua` with things like
```lua
vim.keymap.set('n', '<c-d>', '<c-d>zz', { silent = true})
vim.keymap.set('n', '<c-u>', '<c-u>zz', { silent = true})
```
- `lua/custom/after.lua` with things like
```lua
vim.cmd([[
  " Tell Vim which characters to show for expanded TABs,
  " trailing whitespace, and end-of-lines. VERY useful!
  set listchars=tab:>\·,trail:\ ,extends:>,precedes:<,nbsp:+

  " Show problematic characters.
  set list

  " Also highlight all tabs and trailing whitespace characters.
  highlight ExtraWhitespace ctermbg=darkred guibg=darkred
  match ExtraWhitespace /\s\+$\|\t/
]])
```

## :pencil2: the changes i propose
this PR adds
- `pcall`s to the `require` function on
  - `custom/options` for `lua/custom/options.lua`
  - `custom/map` for `lua/custom/map.lua`
  - `custom/after` for `lua/custom/after.lua`
- `NOTE`s on the three `pcall`s to guide the user, with a similar message as the one for `custom/plugins/*`
- the default options of `kickstart.nvim` have been put to the top of `init.lua`, i.e. before the `lazy` setup (see the comment below for my investigation on that)

thanks to the `pcall`s, the user does not have to use these files, but can add config in them to avoid changing the main `init.lua` file!

hope you'll like it, cheers :tada: :wave: 