### PR TITLE
nvim-treesitter.configs: Rename help to vimdoc

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -288,7 +288,7 @@ vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { de
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'help', 'vim' },
+  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'vimdoc', 'vim' },
 
   -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
   auto_install = false,


### PR DESCRIPTION
To reflect change 93fa5df from 'nvim-treesitter/nvim-treesitter'
Otherwise this error will be thrown:
> Installation not possible: ...vim/lazy/nvim-treesitter/lua/nvim-treesitter/install.lua:86: Parser not available for language "help"