### PR TITLE
help treesitter module has been renamed to vimdoc in master

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -288,7 +288,7 @@ vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { de
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'help', 'vim' },
+  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'vimdoc', 'vim' },
 
   -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
   auto_install = false,


### PR DESCRIPTION
Following [this change](https://github.com/neovim/neovim/commit/d7f7450017b9b05303698a6cda54303ef22c63b3) in neovim master, the help treesitter language has been renamed 'vimdoc' which will break the current config when this is released.