### PR TITLE
Replace "help" with "vimdoc" in treesitter default parser list

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -288,7 +288,7 @@ vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { de
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'help', 'vim' },
+  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'vimdoc', 'vim' },
 
   -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
   auto_install = false,


### PR DESCRIPTION
I'm getting this error when starting Neovim with a fresh setup:

```
Installation not possible: ...vim/lazy/nvim-treesitter/lua/nvim-treesitter/install.lua:86: Parser not available for lan
guage "help"
```

This looks to be related to a new breaking nvim-treesitter change described [here](https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1492982270).

Thanks for making it super easy to get up-and-running!