### PR TITLE
fix: use :TSInstall on build with nvim-treesitter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -167,9 +167,7 @@ require('lazy').setup({
     dependencies = {
       'nvim-treesitter/nvim-treesitter-textobjects',
     },
-    config = function()
-      pcall(require('nvim-treesitter.install').update { with_sync = true })
-    end,
+    build = ":TSUpdate",
   },
 
   -- NOTE: Next Step on Your Neovim Journey: Add/Configure additional "plugins" for kickstart


### PR DESCRIPTION
# Problem

`config` is ran on every start with `lazy.nvim` which means it will try to update the parsers on every start. This may lead to performance problems like this: https://github.com/folke/lazy.nvim/issues/717
It is also installing the parsers synchronously which is really slow

# Solution

use the `build` key which is checked on every plugin install/update. Also use `:TSUpdate` which installs asynchronously. It also seem to be using libuv under the hood compared to the sync version which seems to be using `vim.fn.system`. `nvim-treesitter` also recommends in their readme to use `:TSUpdate` on the hook provided by the package-manager: https://github.com/nvim-treesitter/nvim-treesitter/blob/0efa55ae2e6676b1a4cb66c5ee31ea295c6ebc2f/README.md?plain=1#L78