### PR TITLE
Issue #204-Fixed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -181,10 +181,9 @@ require('lazy').setup({
   --    up-to-date with whatever is in the kickstart repo.
   --
   --    For additional information see: https://github.com/folke/lazy.nvim#-structuring-your-plugins
-  --
-  --    An additional note is that if you only copied in the `init.lua`, you can just comment this line
-  --    to get rid of the warning telling you that there are not plugins in `lua/custom/plugins/`.
-  { import = 'custom.plugins' },
+  --    To insall plugins in future, use the below line as syntax, replace custom.plugins with plugin your are
+  --    willing to install. As mentioned, for additional information, visit the github page mentioed above.
+  --{ import = 'custom.plugins' },
 }, {})
 
 -- [[ Setting options ]]


### PR DESCRIPTION
### Majority of new installs throwing this error
**ERROR**
No specs found for module custom.plugins
**SITUATION**
Normal usage of nvim
**ORIGIN**
Line : 187 throws error guarantied, as there is no custom.plugins plugins plugin, it's just syntax ref for future purposes.
**FIX**
1.Just commented the line that's causing error
2.Mentioned it is a syntax, to add plugins in future, as it was intended.