### PR TITLE
Python debug configuration is added

### DIFF
--- a/lua/kickstart/plugins/dap/handler/python.lua
+++ b/lua/kickstart/plugins/dap/handler/python.lua
@@ -1,8 +1,9 @@
 local dap = require('dap')
 return function()
+    local python_install_path = vim.fn.exepath('python')
     dap.adapters.python = {
       type = "executable",
-      command = "/usr/local/bin/python", -- use "which python" command and provide the python path
+      command = python_install_path, -- use "which python" command and provide the python path
       args = {
         "-m",
         "debugpy.adapter",

--- a/lua/kickstart/plugins/dap/handler/python.lua
+++ b/lua/kickstart/plugins/dap/handler/python.lua
@@ -1,0 +1,46 @@
+local dap = require('dap')
+return function()
+    dap.adapters.python = {
+      type = "executable",
+      command = "/usr/local/bin/python", -- use "which python" command and provide the python path
+      args = {
+        "-m",
+        "debugpy.adapter",
+      },
+    }
+
+    dap.configurations.python = {
+      {
+        type = "python",
+        request = "launch",
+        name = "Launch file",
+        program = "${file}", -- This configuration will launch the current file if used.
+        console= "integratedTerminal",
+      },
+      {
+        name= "Pytest: Current File",
+        type= "python",
+        request= "launch",
+        module= "pytest",
+        args= {
+            "${file}",
+            "-sv",
+            "--log-cli-level=INFO",
+            "--log-file=test_out.log"
+        },
+        console= "integratedTerminal",
+      },
+      {
+        name= "Profile python: Current File",
+        type= "python",
+        request= "launch",
+        module= "cProfile",
+        args= {
+            "-o",
+            "/tmp/profile.dat",
+            "${file}"
+        },
+        console= "integratedTerminal",
+      },
+    }
+  end

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -32,13 +32,18 @@ return {
 
       -- You can provide additional configuration to the handlers,
       -- see mason-nvim-dap README for more information
-      handlers = {},
+      handlers = {
+        -- python debug configuration is available in this file. Uncomment to add python support
+        -- python = require('kickstart.plugins.dap.handler.python'),
+
+      },
 
       -- You'll need to check that you have the required things installed
       -- online, please don't ask me how to install them :)
       ensure_installed = {
         -- Update this to ensure that you have the debuggers for the langs you want
         'delve',
+        'python'
       },
     }
 


### PR DESCRIPTION
Python debug DAP configuration is added for handlers.

This sample can be helpful for beginners who wanted to debug python.

I spent 2 weeks to figure it out. Thought of adding the sample here so that others need not to spend the same amount of time. 

Thank you so much for this kickstart.nvim .
