### PR TITLE
Dapui.toggle keymap is added

### DIFF
--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -72,7 +72,9 @@ return {
         },
       },
     }
-
+    -- toggle to see last session result. Without this ,you can't see session output in case of unhandled exception.
+    vim.keymap.set("n", "<F7>", dapui.toggle)
+    
     dap.listeners.after.event_initialized['dapui_config'] = dapui.open
     dap.listeners.before.event_terminated['dapui_config'] = dapui.close
     dap.listeners.before.event_exited['dapui_config'] = dapui.close


### PR DESCRIPTION
DapUI toggle example is added.

Without toggle function, after the debugging is over we can't see the last session result.
Most of the time it will be required especially when unhandled exception closes the dapui, this toggle will be helpful to see the last time result.