### PR TITLE
setup a standard binding for searching git files using telescope

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -276,6 +276,7 @@ vim.keymap.set('n', '<leader>/', function()
   })
 end, { desc = '[/] Fuzzily search in current buffer' })
 
+vim.keymap.set('n', '<leader>gf', require('telescope.builtin').git_files, { desc = 'Search [G]it [F]iles' })
 vim.keymap.set('n', '<leader>sf', require('telescope.builtin').find_files, { desc = '[S]earch [F]iles' })
 vim.keymap.set('n', '<leader>sh', require('telescope.builtin').help_tags, { desc = '[S]earch [H]elp' })
 vim.keymap.set('n', '<leader>sw', require('telescope.builtin').grep_string, { desc = '[S]earch current [W]ord' })


### PR DESCRIPTION
I think it is quite important to introduce the git_files search using telescope.
For me starting with telescope, I got quite confused using the telescope find_files. It takes into account `.gitignore`, but it also doesn't show any other files starting with a dot. However it is a usual thing in a development workflow.
On contrary `git_files` will show you all files, while hiding `.git/` and files listed in `.gitignore` by default.

fixes #284 