### PR TITLE
corrected git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Distribution Alternatives:
     `~/.config/nvim` (MacOS)
     `%userprofile%\AppData\Local\nvim-data\` (Windows)
 
-* run: git clone https://github.com/nvim-lua/kickstart.nvim.git OR: gh repo clone nvim-lua/kickstart.nvim
+* run: `git clone https://github.com/nvim-lua/kickstart.nvim.git ~/.config/nvim` OR: gh repo clone nvim-lua/kickstart.nvim
 * Run neovim (from terminal or shortcut) and allow the kickstart process to download files and set up the basics.
 * Once the setup is complete restart Neovim.
 * **You're ready to go!**


### PR DESCRIPTION
the earlier `git clone` command created `kickstart.nvim` folder inside `~/.config/nvim` folder.
Corrected this behaviour.