### PR TITLE
change luasnip tab jumping to locally jumpable

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -478,7 +478,7 @@ cmp.setup {
     ['<S-Tab>'] = cmp.mapping(function(fallback)
       if cmp.visible() then
         cmp.select_prev_item()
-      elseif luasnip.jumpable(-1) then
+      elseif luasnip.locally_jumpable(-1) then
         luasnip.jump(-1)
       else
         fallback()

--- a/init.lua
+++ b/init.lua
@@ -469,7 +469,7 @@ cmp.setup {
     ['<Tab>'] = cmp.mapping(function(fallback)
       if cmp.visible() then
         cmp.select_next_item()
-      elseif luasnip.expand_or_jumpable() then
+      elseif luasnip.expand_or_locally_jumpable() then
         luasnip.expand_or_jump()
       else
         fallback()


### PR DESCRIPTION
**Issue**: When using `luasnip.expand_or_jumpable`, if our window includes the snippet but our cursor is not within it, hitting tab can bring us back into the snippet, an annoying and unexpected behavior for new users. 

This is especially annoying when a user manually edits a snippet (e.g. by not using `Tab`, scrolling over to it); LuaSnip or cmp will not register that the snippet is done, and hitting tab takes us back to the snippet unexpectedly.

**Proposed Solution**: Changing this to `luasnip.expand_or_locally_jumpable` would make it so that we'd only jump if our cursor is inside of the snippet, which I believe more users are used to having from other development environments. Carry this forward to `S-Tab` behavior by switching `jumpable(-1)` to `locally_jumpable(-1)`. 