### PR TITLE
Fix init.lua conflicting (with vimdiff) keybinding

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -112,8 +112,6 @@ require('lazy').setup({
         changedelete = { text = '~' },
       },
       on_attach = function(bufnr)
-        vim.keymap.set('n', '[c', require('gitsigns').prev_hunk, { buffer = bufnr, desc = 'Go to Previous Hunk' })
-        vim.keymap.set('n', ']c', require('gitsigns').next_hunk, { buffer = bufnr, desc = 'Go to Next Hunk' })
         vim.keymap.set('n', '<leader>ph', require('gitsigns').preview_hunk, { buffer = bufnr, desc = '[P]review [H]unk' })
       end,
     },


### PR DESCRIPTION
`[c` and `]c` conflict with vimdiff and is not overwritable