### PR TITLE
Template for optionally using system installed language servers on a per-server basis

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -419,8 +419,8 @@ end
 local servers = {
   -- clangd = {},
   -- gopls = {},
-  -- pyright = {},
-  -- rust_analyzer = {},
+  --  pyright = {},
+  --  rust_analyzer = {},
   -- tsserver = {},
 
   lua_ls = {
@@ -430,6 +430,22 @@ local servers = {
     },
   },
 }
+
+local system_server_cmds = {
+  -- clangd = { 'clangd' },
+  -- gopls = { '/usr/local/bin/gopls' },
+  -- pyright = { 'pyright' },
+  -- rust_analyzer = { 'rust-analyzer' },
+  -- tsserver = { 'tsserver' },
+  -- lua_ls = { 'lua-language-server' },
+}
+
+local mason_server_install = {}
+for server_name, _ in pairs(servers) do
+  if system_server_cmds[server_name] == nil then
+    table.insert(mason_server_install, server_name)
+  end
+end
 
 -- Setup neovim lua configuration
 require('neodev').setup()
@@ -442,7 +458,7 @@ capabilities = require('cmp_nvim_lsp').default_capabilities(capabilities)
 local mason_lspconfig = require 'mason-lspconfig'
 
 mason_lspconfig.setup {
-  ensure_installed = vim.tbl_keys(servers),
+  ensure_installed = mason_server_install
 }
 
 mason_lspconfig.setup_handlers {
@@ -454,6 +470,15 @@ mason_lspconfig.setup_handlers {
     }
   end,
 }
+
+for server_name, launch_cmd in pairs(system_server_cmds) do
+  require('lspconfig')[server_name].setup {
+    capabilities = capabilities,
+    on_attach = on_attach,
+    settings = servers[server_name],
+    cmd = launch_cmd,
+  }
+end
 
 -- nvim-cmp setup
 local cmp = require 'cmp'


### PR DESCRIPTION
Added the option to use locally installed language server executables rather than having to use those installed by `mason`.

This option is helpful in that some language servers are installed along with language compiler by package manager, like `clangd` is usually bundled with `clang/LLVM`. Having the underlying system's package manager would update language servers along with the rest of system as well as reducing duplicate downloading and installation introduced by `mason`, saving some disk spaces.

The option is disabled by default and *no specific language server config changes are made*, so as to be compatible with previous versions. Existing user-specific configurations can merge this change seamlessly. 

Choice of using system servers is done on a per server basis, meaning that a user can, say, opt for locally installed `/usr/bin/clangd` while also have `lua_ls` managed by `mason`.  
Detailed comments on instructions of configuring locally installed servers is provided, along with explanations of logic code.

I am well aware of that commits on custom language server configuration is forbidden to be merged. While this commit is indeed about language server configuration, it is *not customized* in any sense, since what this commit offers is a template for using locally installed servers, but no specific change is written into that template.  
In other words, this commit induces no imminent changes to users since no customization is made. **The updated version is still an empty language server configuration as before**, but subsequent users now have one more option when doing customization: an option to use some locally installed servers. And they can safely ignore that and configure like before since the option is, by default, disabled. 

#### Demo of using a system language server:

![Screenshot_2023-05-20_10-34-11](https://github.com/nvim-lua/kickstart.nvim/assets/95068669/e972c8b7-a2f8-4746-908d-331942470069)  
(Enabled `clangd` for the screenshot, which is **not** committed. The committed `init.lua` has default settings as before.)
