### PR TITLE
Adding autocompletion to brackets and quotes.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -71,6 +71,9 @@ require('lazy').setup({
 
   -- Detect tabstop and shiftwidth automatically
   'tpope/vim-sleuth',
+    
+  -- Automatically append closing quotes and brackets when typing
+  'cohama/lexima.vim'
 
   -- NOTE: This is where your plugins related to LSP can be installed.
   --  The configuration is done below. Search for lspconfig to find it below.


### PR DESCRIPTION
Adding a small autocomplete plugin to the plugin list. The functionality is described succinctly [here](https://github.com/cohama/lexima.vim#basic-rules).

This input rule is a common feature in modern IDEs and I think it would make the transition from other editors to NVIM more smooth.