### PR TITLE
fix(docs): update windows path to a correct folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Distribution Alternatives:
 * **You're ready to go!**
 
 * (Recommended/Optional) Fork this repo (so that you have your own copy that you can modify).
-* Clone the kickstart repo into `$HOME/.config/nvim/` (Linux/Mac) or `%userprofile%\AppData\Local\nvim-data\` (Windows)
+* Clone the kickstart repo into `$HOME/.config/nvim/` (Linux/Mac) or `%userprofile%\AppData\Local\nvim\` (Windows)
   * If you don't want to include it as a git repo, you can just clone it and then move the files to this location
 
 Additional system requirements:


### PR DESCRIPTION
the path `nvim-data` on windows is not picked up by nvim by default
this PR changes it to the correct folder.

see also https://github.com/nvim-lua/kickstart.nvim/issues/314