### PR TITLE
Refactor the theme & status line configurations into their own lua files

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -129,28 +129,11 @@ require('lazy').setup({
     },
   },
 
-  {
-    -- Theme inspired by Atom
-    'navarasu/onedark.nvim',
-    priority = 1000,
-    config = function()
-      vim.cmd.colorscheme 'onedark'
-    end,
-  },
+  -- Theme related configs go here
+  require 'kickstart.plugins.theme',
 
-  {
-    -- Set lualine as statusline
-    'nvim-lualine/lualine.nvim',
-    -- See `:help lualine.txt`
-    opts = {
-      options = {
-        icons_enabled = false,
-        theme = 'onedark',
-        component_separators = '|',
-        section_separators = '',
-      },
-    },
-  },
+  -- Status line related configs go here
+  require 'kickstart.plugins.statusline',
 
   {
     -- Add indentation guides even on blank lines

--- a/lua/kickstart/plugins/statusline.lua
+++ b/lua/kickstart/plugins/statusline.lua
@@ -1,0 +1,14 @@
+return  {
+  -- Set lualine as statusline
+  'nvim-lualine/lualine.nvim',
+  -- See `:help lualine.txt`
+  opts = {
+    options = {
+      icons_enabled = false,
+      theme = 'onedark',
+      component_separators = '|',
+      section_separators = '',
+    },
+  },
+}
+

--- a/lua/kickstart/plugins/theme.lua
+++ b/lua/kickstart/plugins/theme.lua
@@ -1,0 +1,9 @@
+return {
+  -- Theme inspired by Atom
+  'navarasu/onedark.nvim',
+  priority = 1000,
+  config = function()
+    vim.cmd.colorscheme 'onedark'
+  end,
+}
+


### PR DESCRIPTION
This change refactors the theme & status line configuration into their own lua files so they can be more readily customized by the user. As kickstart has grown, it's becoming harder and harder to keep up with changes to the main init.lua file if you're maintaining local customizations. We should still encourage users to modify init.lua to suit their needs, but also make it possible to leave it unmodified if that's their choice.

I realize theme related change is a bottomless pit so I'm not suggesting ANY change to the actual theme choices.

However as a partially blind user I simply can't use the onedark scheme chosen, and over time I've struggled with maintaining and integrating my alternate theme choice in amongst the other upstream changes to init.lua, so I think we could save everyone some pain and complexity despite the addition of two more files.

I know that's a bit of a sacred cow to some but I hope you'll at least appreciate the spirit of my suggestion if not the change itself :)