### PR TITLE
Fixes #336 - Enabale treesitter indent for Python

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -295,7 +295,7 @@ require('nvim-treesitter.configs').setup {
   auto_install = false,
 
   highlight = { enable = true },
-  indent = { enable = true, disable = { 'python' } },
+  indent = { enable = true },
   incremental_selection = {
     enable = true,
     keymaps = {


### PR DESCRIPTION
Tested in my local configuratoin. Indenting works great.

@mech-a Hopefully I'm not abusing your good graces, but would you be willing to give this a shot? :) If you think it's OK I'll merge it.