### PR TITLE
Add legacy tag to fidget to avoid deprecation warning

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -84,7 +84,7 @@ require('lazy').setup({
 
       -- Useful status updates for LSP
       -- NOTE: `opts = {}` is the same as calling `require('fidget').setup({})`
-      { 'j-hui/fidget.nvim', opts = {} },
+      { 'j-hui/fidget.nvim', tag = 'legacy', opts = {} },
 
       -- Additional lua configuration, makes nvim stuff amazing!
       'folke/neodev.nvim',


### PR DESCRIPTION
Small fix - `fidget.nvim` is having a full rewrite so we need to check out the "legacy" tag there to avoid a deprecation warning

see: [fidget issue](https://github.com/j-hui/fidget.nvim/issues/131), and [relevant commit](https://github.com/j-hui/fidget.nvim/commit/c93c07c219bcf78c26b144027fcfd20cd23e55bd)