### PR TITLE
Use call_parentheses = "None"

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -3,4 +3,4 @@ line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferSingle"
-no_call_parentheses = true
+call_parentheses = "None"


### PR DESCRIPTION
`no_call_parentheses` has been deprecated: https://github.com/JohnnyMorganz/StyLua/blob/0d4decb462b2eb84d5e7ef1f8feba39c9890bdae/CHANGELOG.md?plain=1#L308-L311