### PR TITLE
Fix typo in ignorecase comment

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -229,7 +229,7 @@ vim.o.breakindent = true
 -- Save undo history
 vim.o.undofile = true
 
--- Case insensitive searching UNLESS /C or capital in search
+-- Case-insensitive searching UNLESS \C or capital in search
 vim.o.ignorecase = true
 vim.o.smartcase = true
 


### PR DESCRIPTION
In order to perform a case-sensitive search with ignorecase, the pattern should contain `\C` instead of `/C`.