### PR TITLE
Remove timout default

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -239,7 +239,6 @@ vim.wo.signcolumn = 'yes'
 
 -- Decrease update time
 vim.o.updatetime = 250
-vim.o.timeout = true
 vim.o.timeoutlen = 300
 
 -- Set completeopt to have a better completion experience


### PR DESCRIPTION
I believe timeout defaults to on, so setting it is not needed.

```
				*'timeout'* *'to'* *'notimeout'* *'noto'*
'timeout' 'to'		boolean (default on)
			global
	This option and 'timeoutlen' determine the behavior when part of a
	mapped key sequence has been received. For example, if <c-f> is
	pressed and 'timeout' is set, Nvim will wait 'timeoutlen' milliseconds
	for any key that can follow <c-f> in a mapping.
```