### PR TITLE
Allow easier overriding of default filetypes for LSP

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -424,12 +424,16 @@ end
 --
 --  Add any additional override configuration in the following tables. They will be passed to
 --  the `settings` field of the server config. You must look up that documentation yourself.
+--
+--  If you want to override the default filetypes that your language server will attach to you can
+--  define the property 'filetypes' to the map in question.
 local servers = {
   -- clangd = {},
   -- gopls = {},
   -- pyright = {},
   -- rust_analyzer = {},
   -- tsserver = {},
+  -- html = { filetypes = { 'html', 'twig', 'hbs'} },
 
   lua_ls = {
     Lua = {
@@ -459,8 +463,9 @@ mason_lspconfig.setup_handlers {
       capabilities = capabilities,
       on_attach = on_attach,
       settings = servers[server_name],
+      filetypes = servers[server_name].filetypes,
     }
-  end,
+  end
 }
 
 -- [[ Configure nvim-cmp ]]


### PR DESCRIPTION
Hi,

For some language servers it makes sense to override the default filetypes that they attach too. For example when editing a twig file it is nice to have the html language server attached to the buffer. 

With this little addition to the setup_handlers function you can just put the filetypes configuration in the server configuration defined above and it will work. If you don't specify filetypes on your lsp config the value set will be nil and the default behavior will occur. 