### PR TITLE
Fix bug when server not explicitely defined in configuration but installed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -463,7 +463,7 @@ mason_lspconfig.setup_handlers {
       capabilities = capabilities,
       on_attach = on_attach,
       settings = servers[server_name],
-      filetypes = servers[server_name].filetypes,
+      filetypes = (servers[server_name] or {}).filetypes,
     }
   end
 }


### PR DESCRIPTION
hi @feoh 

The  problem was that kickstart initializes all LSP's that are installed and not only the ones explicitly defined in your servers variable. I locally had not done this so I did not realize this at the time. 

Here I add a conditional check to see if servers[server_name] is explicitly defined in servers and if not to just set nil on the filetypes variable

This fixes #375 