### PR TITLE
Add comma to init.lua in fuzzy finder dependencies

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -171,7 +171,7 @@ require('lazy').setup({
     'nvim-telescope/telescope.nvim',
     branch = '0.1.x',
     dependencies = {
-      'nvim-lua/plenary.nvim'
+      'nvim-lua/plenary.nvim',
       -- Fuzzy Finder Algorithm which requires local dependencies to be built.
       -- Only load if `make` is available. Make sure you have the system
       -- requirements installed.


### PR DESCRIPTION
Fixes the following regression from #384 :
```
Error detected while processing /Users/juanrtech/.config/nvim/init.lua:
E5112: Error while creating lua chunk: /Users/juanrtech/.config/nvim/init.lua:178: '}' expected (to close '{' at line 173) near '{'
```