### PR TITLE
add `smart add to quickfix list` for telescope

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -283,6 +283,10 @@ require('telescope').setup {
       i = {
         ['<C-u>'] = false,
         ['<C-d>'] = false,
+        ['<C-q>'] = require('telescope.actions').smart_add_to_qflist + require('telescope.actions').open_qflist
+      },
+      n = {
+        ['<C-q>'] = require('telescope.actions').smart_add_to_qflist + require('telescope.actions').open_qflist
       },
     },
   },


### PR DESCRIPTION
Rebound default mapping of ['<C-q>'] to the telescope.action to use the smart adding of items to a quickfix list in the case users toggle matches of results without breaking the original functionality of all matches being added to a quickfix list.