### PR TITLE
Revert gitsigns keymaps but fix vimdiff and fugitive conflict

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -124,9 +124,20 @@ require('lazy').setup({
         changedelete = { text = '~' },
       },
       on_attach = function(bufnr)
-        vim.keymap.set('n', '<leader>gp', require('gitsigns').prev_hunk, { buffer = bufnr, desc = '[G]o to [P]revious Hunk' })
-        vim.keymap.set('n', '<leader>gn', require('gitsigns').next_hunk, { buffer = bufnr, desc = '[G]o to [N]ext Hunk' })
-        vim.keymap.set('n', '<leader>ph', require('gitsigns').preview_hunk, { buffer = bufnr, desc = '[P]review [H]unk' })
+        vim.keymap.set('n', '<leader>hp', require('gitsigns').preview_hunk, { buffer = bufnr, desc = 'Preview git hunk' })
+
+        -- don't override the built-in and fugitive keymaps
+        local gs = package.loaded.gitsigns
+        vim.keymap.set({'n', 'v'}, ']c', function()
+          if vim.wo.diff then return ']c' end
+          vim.schedule(function() gs.next_hunk() end)
+          return '<Ignore>'
+        end, {expr=true, buffer = bufnr, desc = "Jump to next hunk"})
+        vim.keymap.set({'n', 'v'}, '[c', function()
+          if vim.wo.diff then return '[c' end
+          vim.schedule(function() gs.prev_hunk() end)
+          return '<Ignore>'
+        end, {expr=true, buffer = bufnr, desc = "Jump to previous hunk"})
       end,
     },
   },


### PR DESCRIPTION
Originally, the keymaps for jumping to next and previous git hunks were `]c` and `[c`. This was changed in #323 (83b65a1) because they overwrote the built-in vimdiff keymaps.

However, the more traditional solution is to have `]c` and `[c` *extend* the built-in keymap. This is what fugitive and gitgutter have been doing for years.

Gitsigns doesn't do this by itself, but it has a recommended keymap configuration on which the present patch is based:

https://github.com/lewis6991/gitsigns.nvim#keymaps

The only thing I've added is to have the keymaps work in visual mode as well, which is the same behavior as the built in vimdiff keymaps.