### PR TITLE
treesitter: ensure 'javascript' installed along with typescript and tsx

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -313,7 +313,7 @@ vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { de
 -- See `:help nvim-treesitter`
 require('nvim-treesitter.configs').setup {
   -- Add languages to be installed here that you want installed for treesitter
-  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'typescript', 'vimdoc', 'vim' },
+  ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'javascript', 'typescript', 'vimdoc', 'vim' },
 
   -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
   auto_install = false,


### PR DESCRIPTION
This parser is actually needed for some *JSX* parsing, and since typescript and tsx are already getting installed, it makes sense to also install the javascript parser.

---

I actually spent three days trying to figure out why my JSX wasn't being parsed and highlighted and it was because of this.
The *three days* of course is also because I'm a neovim noob trying to modernize my tools after years of vim+ctags. I had to first understand that some of the highlighting is done by `tsserver` LSP. Then I had to learn what tree-sitter is. Eventually I tried to run `:InspectTree` to clearly see that it is complaining about a missing parser. And here we are.👏

The situation is made more difficult given the plethora of treesitter highlighting bug reports for neovim in the recent past, which were all irrelevant to my problem and mostly already resolved because the treesitter neovim integreation has moved so fast over the past couple of years!

This is all to say: this project aims to minimize noob pain (and it mostly succeeds, thank you!), and including the javascript treesitter parser might help alleviate a lot of noob pain.