### PR TITLE
DRAFT - not a real suggestion

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -146,9 +146,6 @@ require('lazy').setup({
     -- Theme inspired by Atom
     'navarasu/onedark.nvim',
     priority = 1000,
-    config = function()
-      vim.cmd.colorscheme 'onedark'
-    end,
   },
 
   {
@@ -223,6 +220,8 @@ require('lazy').setup({
   --    For additional information see: https://github.com/folke/lazy.nvim#-structuring-your-plugins
   -- { import = 'custom.plugins' },
 }, {})
+
+vim.cmd.colorscheme 'onedark'
 
 -- [[ Setting options ]]
 -- See `:help vim.o`


### PR DESCRIPTION
This is not an actual suggestion. But doing this did remove the error message and I just thought I'd show it. I'm guessing doing this in the `config` function allows it to only happen once the colorscheme is loaded via lazy.nvim. And I'd love to get that working. But it just isn't at the moment.

Fix #430