### PR TITLE
fix(init.lua): indent blankline v3 setup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -170,10 +170,12 @@ require('lazy').setup({
     'lukas-reineke/indent-blankline.nvim',
     -- Enable `lukas-reineke/indent-blankline.nvim`
     -- See `:help indent_blankline.txt`
-    opts = {
-      char = '┊',
-      show_trailing_blankline_indent = false,
-    },
+    config = function()
+      require('ibl').setup {
+        char = '┊',
+        show_trailing_blankline_indent = false,
+      }
+    end,
   },
 
   -- "gc" to comment visual regions/lines


### PR DESCRIPTION
Indent blankline plugin v3 setup throws error when called with `opts = {...}`