### PR TITLE
fix: fix indent-blankline config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -170,12 +170,8 @@ require('lazy').setup({
     'lukas-reineke/indent-blankline.nvim',
     -- Enable `lukas-reineke/indent-blankline.nvim`
     -- See `:help indent_blankline.txt`
-    config = function()
-      require('ibl').setup {
-        char = '┊',
-        show_trailing_blankline_indent = false,
-      }
-    end,
+    main = "ibl",
+    opts = {},
   },
 
   -- "gc" to comment visual regions/lines


### PR DESCRIPTION
#443 updated to v3, but now the configuration is wrong.
`char` and `show_trailing_blankline_indent` are not valid options like this anymore.

`show_trailing_blankline_indent` is removed, it's always false now.

If you want to keep `char`, it would be `opts = { indent = { char = "┊" } }`, but I recommend leaving the default, or it looks weird with the scope.

![2023-09-28_23-16](https://github.com/lukas-reineke/kickstart.nvim/assets/12900252/9a54e8b6-129b-41c0-9557-0109b79dfcf1)
vs
![2023-09-28_23-17](https://github.com/lukas-reineke/kickstart.nvim/assets/12900252/d0146ec5-b8cd-4959-b59d-07b4419a6bbb)
