### PR TITLE
Fix Treesitter bash errors when editing README.md 

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -333,7 +333,7 @@ vim.keymap.set('n', '<leader>sr', require('telescope.builtin').resume, { desc = 
 vim.defer_fn(function()
   require('nvim-treesitter.configs').setup {
     -- Add languages to be installed here that you want installed for treesitter
-    ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'javascript', 'typescript', 'vimdoc', 'vim' },
+    ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'javascript', 'typescript', 'vimdoc', 'vim', 'bash' },
 
     -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
     auto_install = false,


### PR DESCRIPTION
Fix the Treesitter bash script errors described in issue #451 when editing or previewing README.md by installing the bash Treesitter parser.

Closes #451.
Closes #457.