### PR TITLE
fix: remove spaces in empty lines

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -326,10 +326,10 @@ vim.defer_fn(function()
   require('nvim-treesitter.configs').setup {
     -- Add languages to be installed here that you want installed for treesitter
     ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'javascript', 'typescript', 'vimdoc', 'vim' },
-  
+
     -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
     auto_install = false,
-  
+
     highlight = { enable = true },
     indent = { enable = true },
     incremental_selection = {


### PR DESCRIPTION
when i check out on the `master` branch of this original fork, i see two diagnostics in `init.lua` about empty lines having spaces in them :open_mouth: 
one can see them once the Lua LSP is done with `[d` or `]d` :wink: 

this PR simply removes the spaces in these two lines, making the diagnostics disappear :yum: 

## the actual diagnostic
```
Diagnostics:
1. Line with spaces only. [trailing-space]
```
on lines 329 and 332