### PR TITLE
Simple misstype fix on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Neovim's configurations are located under the following paths, depending on your
 | OS | PATH |
 | :- | :--- |
 | Linux | `$XDG_CONFIG_HOME/nvim`, `~/.config/nvim` |
-| MacOS | `$XDG_CONFIG_HOME/nvim`, '~/.config/nvim` |
+| MacOS | `$XDG_CONFIG_HOME/nvim`, `~/.config/nvim` |
 | Windows | `%userprofile%\AppData\Local\nvim\` |
 
 Clone kickstart.nvim:


### PR DESCRIPTION
I've fixed a simple misstype based on markdown syntax. 

## Before
| MacOS | `$XDG_CONFIG_HOME/nvim`, '~/.config/nvim` |
## After
| MacOS | `$XDG_CONFIG_HOME/nvim`, `~/.config/nvim` |