### PR TITLE
Fix help for indent-blankline plugin

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -177,7 +177,7 @@ require('lazy').setup({
     -- Add indentation guides even on blank lines
     'lukas-reineke/indent-blankline.nvim',
     -- Enable `lukas-reineke/indent-blankline.nvim`
-    -- See `:help indent_blankline.txt`
+    -- See `:help ibl`
     main = 'ibl',
     opts = {},
   },


### PR DESCRIPTION
Since version 3 `:help indent_blankline` no longer works. Replace it with `:help ibl`.