### PR TITLE
disabling ibl scope by default

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -179,7 +179,9 @@ require('lazy').setup({
     -- Enable `lukas-reineke/indent-blankline.nvim`
     -- See `:help indent_blankline.txt`
     main = 'ibl',
-    opts = {},
+    opts = {
+      scope = { enabled = false },
+    },
   },
 
   -- "gc" to comment visual regions/lines


### PR DESCRIPTION
I don't know what you think, but I personally don't like this kind of scope highlighting. And worst, I spent quite some time to find out which plugin introduced this feature. For me is not intuitive that an indentation blank line plugin could also highlight scopes, so maybe we should disabled this feature by default.

<img width="971" alt="image" src="https://github.com/nvim-lua/kickstart.nvim/assets/2567548/79ae4b34-4a7a-40bb-b1e6-0620c3563381">
