### PR TITLE
Use Telescope builtin functions for LSP definition and type definition

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -422,10 +422,10 @@ local on_attach = function(_, bufnr)
   nmap('<leader>rn', vim.lsp.buf.rename, '[R]e[n]ame')
   nmap('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction')
 
-  nmap('gd', vim.lsp.buf.definition, '[G]oto [D]efinition')
+  nmap('gd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
   nmap('gr', require('telescope.builtin').lsp_references, '[G]oto [R]eferences')
   nmap('gI', require('telescope.builtin').lsp_implementations, '[G]oto [I]mplementation')
-  nmap('<leader>D', vim.lsp.buf.type_definition, 'Type [D]efinition')
+  nmap('<leader>D', require('telescope.builtin').lsp_type_definitions, 'Type [D]efinition')
   nmap('<leader>ds', require('telescope.builtin').lsp_document_symbols, '[D]ocument [S]ymbols')
   nmap('<leader>ws', require('telescope.builtin').lsp_dynamic_workspace_symbols, '[W]orkspace [S]ymbols')
 


### PR DESCRIPTION
I thought it was a little odd that every other LSP features use Telescope builtin but not those two. It will allow easier navigation when there are multiple symbol definitions.

We can also potentially do something like the following snippet to be safer and provide an example of `pcall`:

```lua
  -- ...
  local status, builtin = pcall(require, 'telescope.builtin')
  if status then
    nmap('gd', builtin.lsp_definitions, '[G]oto [D]efinition')
    -- ...
  else
    nmap('gd', vim.lsp.buf.definition, '[G]oto [D]efinition')
    -- ...
  end
```

Although I am not sure it will be necessary since Telescope is very widely used in Kickstart and it might clutter the config and confuse beginners.