### PR TITLE
Update README Post Installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ git clone https://github.com/nvim-lua/kickstart.nvim.git %userprofile%\AppData\L
 
 ### Post Installation
 
-Run the following command and then **you are ready to go**!
+Start Neovim
+
+```sh
+nvim
+```
+
+The `Lazy` plugin manager will start automatically on the first run and install the configured plugins - as can be seen in the introduction video. After the installation is complete you can press `q` to close the `Lazy` UI and **you are ready to go**! Next time you run nvim `Lazy` will no longer show up.
+
+If you would prefer to hide this step and run the plugin sync from the command line, you can use:
 
 ```sh
 nvim --headless "+Lazy! sync" +qa


### PR DESCRIPTION
As discussed here:
https://github.com/nvim-lua/kickstart.nvim/issues/478

Change the recommendation to just run nvim normally instead of the headless mode for the first run. This will show Lazy UI updating the plugins which would match what the video show and may be easier to understand what is going on thant the silent headless run.

Perhaps now it is too verbose? Let me know if you would prefer to word it differently.
