### PR TITLE
Differences in CMD and Powershell env variables. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Neovim's configurations are located under the following paths, depending on your
 | :- | :--- |
 | Linux | `$XDG_CONFIG_HOME/nvim`, `~/.config/nvim` |
 | MacOS | `$XDG_CONFIG_HOME/nvim`, `~/.config/nvim` |
-| Windows | `%userprofile%\AppData\Local\nvim\` |
+| Windows (cmd)| `%userprofile%\AppData\Local\nvim\` |
+| Windows (powershell)| `$env:USERPROFILE\AppData\Local\nvim\` |
 
 Clone kickstart.nvim:
 
@@ -45,9 +46,15 @@ git clone https://github.com/nvim-lua/kickstart.nvim.git "${XDG_CONFIG_HOME:-$HO
 
 
 ```
-# on Windows
+# on Windows (cmd)
 git clone https://github.com/nvim-lua/kickstart.nvim.git %userprofile%\AppData\Local\nvim\ 
 ```
+
+```
+# on Windows (powershell)
+git clone https://github.com/nvim-lua/kickstart.nvim.git $env:USERPROFILE\AppData\Local\nvim\ 
+```
+
 
 ### Post Installation
 


### PR DESCRIPTION
Added information on how to install if you use Powershell in windows. Since CMD and Powershell work differently.

`%userprofile%` only works for the CMD application. `$env:USERPROFILE` works in Powershell.