### PR TITLE
README.md: Added a FAQ: why is init.lua a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ Each PR, especially those which increase the line count, should have a descripti
 * Are there any cool videos about this plugin?
   * Current iteration of kickstart (coming soon)
   * Here is one about the previous iteration of kickstart: [video introduction to Kickstart.nvim](https://youtu.be/stqUbv-5u2s). Note the install via init.lua no longer works as specified. Please follow the install instructions in this file instead as they're up to date.
+* Why is the kickstart `init.lua` a single file? Wouldn't it make sense to split it into multiple files?
+  * The main purpose of kickstart is to serve as a teaching tool and a reference
+    configuration that someone can easily `git clone` as a basis for their own.
+    As you progress in learning Neovim and Lua, you might consider splitting `init.lua`
+    into smaller parts. A fork of kickstart that does this while maintaining the exact
+    same functionality is available here:
+    * [kickstart-modular.nvim](https://github.com/dam9000/kickstart-modular.nvim)
+  * Discussions on this topic can be found here:
+    * [Restructure the configuration](https://github.com/nvim-lua/kickstart.nvim/issues/218)
+    * [Reorganize init.lua into a multi-file setup](https://github.com/nvim-lua/kickstart.nvim/pull/473)
 
 ### Windows Installation
 


### PR DESCRIPTION
In the PR comment: https://github.com/nvim-lua/kickstart.nvim/pull/473#issuecomment-1774303260
It was suggested that a note would be added to the README regarding the single vs multi file approach of init.lua,
So here is a PR that adds a section in FAQ about the single file vs multi-file approach and a link to the multi-file fork.
Not sure if I formulated it the best, if you have some additional suggestions let me know.
(or close if you feel this does not belong here)
