### PR TITLE
Live Grep from Git root falls back to cwd on special buffers

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -313,18 +313,21 @@ pcall(require('telescope').load_extension, 'fzf')
 local function find_git_root()
   -- Use the current buffer's path as the starting point for the git search
   local current_file = vim.api.nvim_buf_get_name(0)
+  local current_dir
+  local cwd = vim.fn.getcwd()
   -- If the buffer is not associated with a file, return nil
   if current_file == "" then
-    print("Buffer is not associated with a file")
-    return nil
+    current_dir = cwd
+  else
+    -- Extract the directory from the current file's path
+    current_dir = vim.fn.fnamemodify(current_file, ":h")
   end
-  -- Extract the directory from the current file's path
-  local current_dir = vim.fn.fnamemodify(current_file, ":h")
+
   -- Find the Git root directory from the current file's path
   local git_root = vim.fn.systemlist("git -C " .. vim.fn.escape(current_dir, " ") .. " rev-parse --show-toplevel")[1]
   if vim.v.shell_error ~= 0 then
-    print("Not a git repository")
-    return nil
+    print("Not a git repository. Searching on current working directory")
+    return cwd
   end
   return git_root
 end


### PR DESCRIPTION
This also falls back to current working dir if dir is not in a git repository.