### PR TITLE
fix(auto-completion): ensure first menu item is selected by default

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -564,6 +564,9 @@ cmp.setup {
       luasnip.lsp_expand(args.body)
     end,
   },
+  completion = {
+    completeopt = 'menu,menuone,noinsert'
+  },
   mapping = cmp.mapping.preset.insert {
     ['<C-n>'] = cmp.mapping.select_next_item(),
     ['<C-p>'] = cmp.mapping.select_prev_item(),


### PR DESCRIPTION
![image](https://github.com/nvim-lua/kickstart.nvim/assets/72117025/8611b2b0-3720-41a7-a3c4-b500ef5ec763)

Now the first item is selected by default.
fixes #487 