### PR TITLE
init.lua: remove 'legacy' tag from fidget.nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -88,7 +88,7 @@ require('lazy').setup({
 
       -- Useful status updates for LSP
       -- NOTE: `opts = {}` is the same as calling `require('fidget').setup({})`
-      { 'j-hui/fidget.nvim', tag = 'legacy', opts = {} },
+      { 'j-hui/fidget.nvim', opts = {} },
 
       -- Additional lua configuration, makes nvim stuff amazing!
       'folke/neodev.nvim',


### PR DESCRIPTION
Since https://github.com/j-hui/fidget.nvim/pull/143, the `legacy` tag is no longer necessary (or recommended) for my plugin.

(Then again, I'm not sure if the point of including fidget.nvim here was to be instructive about how Lazy `tag`s work, so maybe this PR defeats the point?)