### PR TITLE
README.md: update install section formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,17 @@ Neovim's configurations are located under the following paths, depending on your
 
 Clone kickstart.nvim:
 
-# on Linux and Mac
+- on Linux and Mac
 ```sh
 git clone https://github.com/nvim-lua/kickstart.nvim.git "${XDG_CONFIG_HOME:-$HOME/.config}"/nvim
 ```
 
-
-# on Windows (cmd)
+- on Windows (cmd)
 ```
 git clone https://github.com/nvim-lua/kickstart.nvim.git %userprofile%\AppData\Local\nvim\ 
 ```
 
-# on Windows (powershell)
+- on Windows (powershell)
 ```
 git clone https://github.com/nvim-lua/kickstart.nvim.git $env:USERPROFILE\AppData\Local\nvim\ 
 ```


### PR DESCRIPTION
The recent change moved the comment from a code block, without removing the `#` which is interpreted as a level 1 heading, not what was intended. Changed to a bullet list.