### PR TITLE
Use alias instead of a wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,11 @@ Each PR, especially those which increase the line count, should have a descripti
   * This includes your existing init.lua and the neovim files in `~/.local` which can be deleted with `rm -rf ~/.local/share/nvim/`
   * You may also want to look at the [migration guide for lazy.nvim](https://github.com/folke/lazy.nvim#-migration-guide)
 * Can I keep my existing configuration in parallel to kickstart?
-  * Yes! You can use [NVIM_APPNAME](https://neovim.io/doc/user/starting.html#%24NVIM_APPNAME)`=nvim-NAME` to maintain multiple configurations. For example you can install the kickstart configuration in `~/.config/nvim-kickstart` and create a script `~/bin/nvim-kickstart`:
+  * Yes! You can use [NVIM_APPNAME](https://neovim.io/doc/user/starting.html#%24NVIM_APPNAME)`=nvim-NAME` to maintain multiple configurations. For example you can install the kickstart configuration in `~/.config/nvim-kickstart` and create an alias:
     ```
-    #!/bin/sh
-    exec env NVIM_APPNAME=nvim-kickstart nvim "$@"
+    alias nvim-kickstart='NVIM_APPNAME="nvim-kickstart" nvim'
     ```
-    When you run Neovim with `nvim-kickstart` it will use the alternative config directory and the matching local directory: `~/.local/share/nvim-kickstart`. You can apply this approach to any Neovim distribution that you would like to try out.
+    When you run Neovim using `nvim-kickstart` alias it will use the alternative config directory and the matching local directory `~/.local/share/nvim-kickstart`. You can apply this approach to any Neovim distribution that you would like to try out.
 * What if I want to "uninstall" this configuration:
   * See [lazy.nvim uninstall](https://github.com/folke/lazy.nvim#-uninstalling) information
 * Are there any cool videos about this plugin?


### PR DESCRIPTION
It is much easier to stick an alias statement in `~/.{z,ba}shrc` than create a script, invoke another instance of interpreter and then run neovim