### PR TITLE
feat(cmp): path completion feature

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -105,6 +105,7 @@ require('lazy').setup({
 
       -- Adds LSP completion capabilities
       'hrsh7th/cmp-nvim-lsp',
+      'hrsh7th/cmp-path',
 
       -- Adds a number of user-friendly snippets
       'rafamadriz/friendly-snippets',
@@ -652,6 +653,7 @@ cmp.setup {
   sources = {
     { name = 'nvim_lsp' },
     { name = 'luasnip' },
+    { name = 'path' },
   },
 }
 


### PR DESCRIPTION
Added path completion feature

- Tested on Linux (should be fine on Windows, but I can't confirm)

![image](https://github.com/nvim-lua/kickstart.nvim/assets/72117025/ad0da8cf-f6a8-4f34-bc75-be10dd1f23ad)

closes #535