### PR TITLE
Switch cmp up mapping from C-d to C-b to match regular vim up key

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -624,7 +624,7 @@ cmp.setup {
   mapping = cmp.mapping.preset.insert {
     ['<C-n>'] = cmp.mapping.select_next_item(),
     ['<C-p>'] = cmp.mapping.select_prev_item(),
-    ['<C-d>'] = cmp.mapping.scroll_docs(-4),
+    ['<C-b>'] = cmp.mapping.scroll_docs(-4),
     ['<C-f>'] = cmp.mapping.scroll_docs(4),
     ['<C-Space>'] = cmp.mapping.complete {},
     ['<CR>'] = cmp.mapping.confirm {


### PR DESCRIPTION
The existing keybinding seems like a typo, since C-d in vim normally scrolls downwards, but C-b scrolls upwards, which seems like the more accurate opposite of C-f.