### PR TITLE
reenable indentation guide

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -218,7 +218,9 @@ require('lazy').setup({
     -- Enable `lukas-reineke/indent-blankline.nvim`
     -- See `:help ibl`
     main = 'ibl',
-    opts = {},
+    opts = { 
+      indent = { char = "|" },
+    },
   },
 
   -- "gc" to comment visual regions/lines


### PR DESCRIPTION
from v2 to v3 the character was moved into the indent dict