### PR TITLE
fix: restore mason config timing for dap startup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -83,7 +83,7 @@ require('lazy').setup({
     'neovim/nvim-lspconfig',
     dependencies = {
       -- Automatically install LSPs to stdpath for neovim
-      'williamboman/mason.nvim',
+      { 'williamboman/mason.nvim', config = true },
       'williamboman/mason-lspconfig.nvim',
 
       -- Useful status updates for LSP


### PR DESCRIPTION
addresses https://github.com/nvim-lua/kickstart.nvim/issues/554