### PR TITLE
Improve stylua github workflow

### DIFF
--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -1,6 +1,6 @@
 # Check Lua Formatting
 name: Check Lua Formatting
-on: pull_request
+on: pull_request_target
 
 jobs:
   stylua-check:
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Stylua Check
         uses: JohnnyMorganz/stylua-action@v3
         with:


### PR DESCRIPTION
Addressing issue nvim-lua/kickstart.nvim#570

This improves the github workflow to no longer require manual approval for PRs from first time contributors.

Changes the github event from pull_request to pull_request_target and adds an explicit PR head checkout