### PR TITLE
README.md: rename the duplicate "Introduction" to "Getting Started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ If you would prefer to hide this step and run the plugin sync from the command l
 nvim --headless "+Lazy! sync" +qa
 ```
 
-### Introduction
+### Getting Started
 
-To get started, see [Effective Neovim: Instant IDE](https://youtu.be/stqUbv-5u2s), covering the previous version. Note: The install via init.lua is outdated, please follow the install instructions in this file instead. An updated video is coming soon.
+See [Effective Neovim: Instant IDE](https://youtu.be/stqUbv-5u2s), covering the previous version. Note: The install via init.lua is outdated, please follow the install instructions in this file instead. An updated video is coming soon.
 
 ### Recommended Steps
 


### PR DESCRIPTION
Changing this second "Introduction" heading to "Getting Started"

The recent change in README which moved the youtube link from FAQ to it's own section used the heading "Introduction" which is already the first heading in the file.