### PR TITLE
Add Missing Fields to Treesitter Config to Resolve Warnings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -424,21 +424,14 @@ vim.defer_fn(function()
   require('nvim-treesitter.configs').setup {
     -- Add languages to be installed here that you want installed for treesitter
     ensure_installed = { 'c', 'cpp', 'go', 'lua', 'python', 'rust', 'tsx', 'javascript', 'typescript', 'vimdoc', 'vim', 'bash' },
-
     -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
     auto_install = false,
     -- Install languages synchronously (only applied to `ensure_installed`)
     sync_install = false, 
     -- List of parsers to ignore installing
     ignore_install = {}, 
-    modules = {
-      -- You can specify additional Treesitter modules here
-      -- For example:
-      -- playground = {
-      --   enable = true,
-      -- },
-    },
-
+    -- You can specify additional Treesitter modules here: -- For example: -- playground = {--enable = true,-- },
+    modules = {},
     highlight = { enable = true },
     indent = { enable = true },
     incremental_selection = {

--- a/init.lua
+++ b/init.lua
@@ -427,9 +427,9 @@ vim.defer_fn(function()
     -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
     auto_install = false,
     -- Install languages synchronously (only applied to `ensure_installed`)
-    sync_install = false, 
+    sync_install = false,
     -- List of parsers to ignore installing
-    ignore_install = {}, 
+    ignore_install = {},
     -- You can specify additional Treesitter modules here: -- For example: -- playground = {--enable = true,-- },
     modules = {},
     highlight = { enable = true },


### PR DESCRIPTION
This commit introduces three additional fields - `sync_install`, `ignore_install`, and `modules` - to the Treesitter configuration. This update is aimed at resolving warnings that were previously displayed, potentially causing confusion or frustration for new users of Neovim. By explicitly defining these fields, the configuration aligns better with the latest `nvim-treesitter` requirements.