### PR TITLE
Add Missing Fields to Treesitter Config to Resolve Warnings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -427,7 +427,14 @@ vim.defer_fn(function()
 
     -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
     auto_install = false,
-
+    -- Autoinstall languages that are not installed. Defaults to false (but you can change for yourself!)
+    auto_install = false,
+    -- Install languages synchronously (only applied to `ensure_installed`)
+    sync_install = false,
+    -- List of parsers to ignore installing
+    ignore_install = {},
+    -- You can specify additional Treesitter modules here: -- For example: -- playground = {--enable = true,-- },
+    modules = {},
     highlight = { enable = true },
     indent = { enable = true },
     incremental_selection = {


### PR DESCRIPTION
This commit introduces three additional fields - `sync_install`, `ignore_install`, and `modules` - to the Treesitter configuration. This update is aimed at resolving warnings that were previously displayed, potentially causing confusion or frustration for new users of Neovim. By explicitly defining these fields, the configuration aligns better with the latest `nvim-treesitter` requirements.