### PR TITLE
Add Onedark Style

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -193,7 +193,11 @@ require('lazy').setup({
     -- Theme inspired by Atom
     'navarasu/onedark.nvim',
     priority = 1000,
+    lazy = false,
     config = function()
+      require('onedark').setup({
+        style = 'dark' -- dark, darker, cool, deep, warm, warmer, light
+      })
       vim.cmd.colorscheme 'onedark'
     end,
   },

--- a/init.lua
+++ b/init.lua
@@ -198,7 +198,7 @@ require('lazy').setup({
       require('onedark').setup {
         style = 'dark', -- dark, darker, cool, deep, warm, warmer, light
       }
-      vim.cmd.colorscheme 'onedark'
+      require('onedark').load()
     end,
   },
 

--- a/init.lua
+++ b/init.lua
@@ -195,9 +195,9 @@ require('lazy').setup({
     priority = 1000,
     lazy = false,
     config = function()
-      require('onedark').setup({
-        style = 'dark' -- dark, darker, cool, deep, warm, warmer, light
-      })
+      require('onedark').setup {
+        style = 'dark', -- dark, darker, cool, deep, warm, warmer, light
+      }
       vim.cmd.colorscheme 'onedark'
     end,
   },

--- a/init.lua
+++ b/init.lua
@@ -196,6 +196,7 @@ require('lazy').setup({
     lazy = false,
     config = function()
       require('onedark').setup {
+        -- Set a style preset. 'dark' is default.
         style = 'dark', -- dark, darker, cool, deep, warm, warmer, light
       }
       require('onedark').load()


### PR DESCRIPTION
I wanted to change the style in my own config, and thought that it wasn't as trivial as I would like it to be.

Default behaviour unchanged. The option to change the Onedark theme are now more exposed to the user.

Lazy-loading defaults to off as recommended by Lazy.nvim for the main theme.

Is the commenting satisfactory on all counts?
