### PR TITLE
Set status line theme to the global colorscheme

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -205,7 +205,7 @@ require('lazy').setup({
     opts = {
       options = {
         icons_enabled = false,
-        theme = 'onedark',
+        theme = 'auto',
         component_separators = '|',
         section_separators = '',
       },


### PR DESCRIPTION
instead of hardcoding the 'onedark' theme.
It allows users to change the Neovim theme globally and to see those changes automatically reflected to the status line.