### PR TITLE
issue: #594 stylua workflow only on official kickstart repo

### DIFF
--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -4,6 +4,7 @@ on: pull_request_target
 
 jobs:
   stylua-check:
+    if: github.repository == 'nvim-lua/kickstart.nvim'
     name: Stylua Check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Only run the github stylua workflow check on the official kickstart repo (nvim-lua/kickstart.nvim) so that it's not enforced on any other forks.
As suggested by: @zwergius