### PR TITLE
Add Build Step to LuaSnip

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -105,7 +105,7 @@ require('lazy').setup({
         build = (function()
           -- Build Step is needed for regex support in snippets
           -- This step is not supported in many windows environments
-          -- Remove if your windows setup supports this
+          -- Remove the below condition to re-enable on windows
           if vim.fn.has 'win32' == 1 then
             return
           end

--- a/init.lua
+++ b/init.lua
@@ -102,7 +102,7 @@ require('lazy').setup({
       -- Snippet Engine & its associated nvim-cmp source
       {
         'L3MON4D3/LuaSnip',
-        build = 'make install_jsregexp'
+        build = 'make install_jsregexp',
       },
       'saadparwaiz1/cmp_luasnip',
 

--- a/init.lua
+++ b/init.lua
@@ -100,7 +100,10 @@ require('lazy').setup({
     'hrsh7th/nvim-cmp',
     dependencies = {
       -- Snippet Engine & its associated nvim-cmp source
-      'L3MON4D3/LuaSnip',
+      {
+        'L3MON4D3/LuaSnip',
+        build = 'make install_jsregexp'
+      },
       'saadparwaiz1/cmp_luasnip',
 
       -- Adds LSP completion capabilities

--- a/init.lua
+++ b/init.lua
@@ -102,7 +102,15 @@ require('lazy').setup({
       -- Snippet Engine & its associated nvim-cmp source
       {
         'L3MON4D3/LuaSnip',
-        build = 'make install_jsregexp',
+        build = (function()
+          -- Build Step is needed for regex support in snippets
+          -- This step is not supported in many windows environments
+          -- Remove if your windows setup supports this
+          if vim.fn.has 'win32' == 1 then
+            return
+          end
+          return 'make install_jsregexp'
+        end)(),
       },
       'saadparwaiz1/cmp_luasnip',
 


### PR DESCRIPTION
`LuaSnip` requires a build step in order to use snippets with Regular Expressions in them. Snippets like these are very common (Header guards in C++). Currently, `kickstart.nvim` does not produce valid header guards. Configuring this would be confusing for beginners, who know that `friendly-snippets` and `LuaSnip` are already installed.
## Example:
### Before: 
```cpp
#ifndef INCLUDE/home/rgarber11/tempconfigconfig.h_
// This is an invalid guard
...
```
### After: 
```cpp
#ifndef INCLUDE_TEMP_CONFIG_H_
// This guard is valid
...
```



