### PR TITLE
Add key mapping to exit terminal mode via ESC

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -342,6 +342,9 @@ vim.keymap.set('n', ']d', vim.diagnostic.goto_next, { desc = 'Go to next diagnos
 vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, { desc = 'Open floating diagnostic message' })
 vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostics list' })
 
+-- Exit terminal mode by simply pressing ESC
+vim.keymap.set('t', '<ESC>', '<C-\\><C-n>', { noremap = true })
+
 -- [[ Highlight on yank ]]
 -- See `:help vim.highlight.on_yank()`
 local highlight_group = vim.api.nvim_create_augroup('YankHighlight', { clear = true })


### PR DESCRIPTION
I was unable to exit the terminal mode using the default shortcut `C-\` followed by `C-n` when using 'de' as keyboard layout. Maybe because of the required additional modifier key to access backspace. This caused me to always `exit` the shell in order to get back to the edit buffers.

I would assume that more people are affected when using a different keyboard layout than 'us' and would benefit from a simpler default.