### PR TITLE
Configure stylua to collapse simple inline lua functions

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -4,3 +4,4 @@ indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferSingle"
 call_parentheses = "None"
+collapse_simple_statement = "FunctionOnly"


### PR DESCRIPTION
After the formatter config change today (unless I am missing something), inline lua functions are getting split into multiple lines.

before:
`vim.keymap.set('n', '<C-j>', function() harpoon:list():select(1) end)`

after:
```
vim.keymap.set('n', '<C-j>', function()
  harpoon:list():select(1)
end)
```

I find inline functions to be concise and useful, and I think others may agree. Unless I am missing something.
The stylua config setting `collapse_simple_statement = "FunctionOnly"` prevents stylua from splitting functions into multiple lines.