### PR TITLE
Fix: Add treesitter option to use pre-compiled binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ return {
 
 Installation may require installing build tools, and updating the run command for `telescope-fzf-native`
 
+Users should follow the [Treesitter Windows
+Installation](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)
+instructions to allow Treesitter language extensions to be downloaded from
+Github.
+
 See `telescope-fzf-native` documentation for [more details](https://github.com/nvim-telescope/telescope-fzf-native.nvim#installation)
 
 This requires:

--- a/init.lua
+++ b/init.lua
@@ -771,6 +771,9 @@ require('lazy').setup({
     build = ':TSUpdate',
     config = function()
       -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
+      -- Use precompiled binaries for faster startup.
+      -- This also means Windows users won't fail on startup by default.
+      require('nvim-treesitter.install').prefer_git = false
 
       ---@diagnostic disable-next-line: missing-fields
       require('nvim-treesitter.configs').setup {


### PR DESCRIPTION
On Windows, when new users install kickstart it blows up by default because having a C compiler in PATH is not a reaonle expectation on hat platform.

Also, this should decrease first use startup time substantially on all platforms because curl-ing down a binary is much faster than compiling from scratch.

Also updated README as Windows folks are expected to turn on developer mode so symlinks and 'curl' will work.