### PR TITLE
Change mini.statusline location format to LINE:COLUMN

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -762,6 +762,9 @@ require('lazy').setup {
       --  You could remove this setup call if you don't like it,
       --  and try some other statusline plugin
       require('mini.statusline').setup()
+      MiniStatusline.section_location = function()
+        return '%2l:%-2v'
+      end
 
       -- ... and there is more!
       --  Check out: https://github.com/echasnovski/mini.nvim


### PR DESCRIPTION
Default mini.statusline location format is:
  'cursor line | total lines │ cursor column | total columns'

For example: `512|816|35|95`

Which just doesn't look good to me. Before the latest kickstart rewrite, the `lualine` location format was LINE:COLUMN (`512:35`) which I think is what most would expect. I understand this is a subjective preference so feel free to discard this PR if you think the current default is fine.

PS. an additional note, as this overwrites a mini.statusline function, the lua diagnostics show a warning:  `Duplicate field 'section_location'` at the added line but it works fine. I didn't find any other elegant way to avoid this warning, at least not with this small number of lines of code. An alternative would take about 30 lines, which seems way too much for such a small change. Perhaps the previous `lualine` was a better statusline plugin option.
