### PR TITLE
Enable custom plugins by default for lazy plugin manager

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -814,7 +814,7 @@ require('lazy').setup {
   --
   --  Uncomment the following line and add your plugins to `lua/custom/plugins/*.lua` to get going.
   --    For additional information see: :help lazy.nvim-lazy.nvim-structuring-your-plugins
-  -- { import = 'custom.plugins' },
+  { import = 'custom.plugins' },
 }
 
 -- The line beneath this is called `modeline`. See `:help modeline`


### PR DESCRIPTION
Closes #665 

I followed the instructions on kickstarter.vim README to add custom plugin.

As an example the instructions asked me to add a new file `lua/custom/plugins/autopairs.lua`.
This did NOT work. 
I wasted hours trying to find out why it did not work, it was frustrating and I almost gave up.

For a beginner to nvim following this guide,
for ease of use custom plugins should load by default.
