### PR TITLE
Add a section on user commands

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -202,10 +202,9 @@ vim.api.nvim_create_autocmd('TextYankPost', {
 -- See `:help lua-guide-commands-create`
 
 -- Quickly jump to your config with this awesome custom command
--- Try it by starting nvim in a random directory and typing :Config
-vim.api.nvim_create_user_command("Config", function()
-  local path = "~/.config/nvim/" -- You can customize the path here
-  vim.cmd("e" .. path)           -- vim.cmd allows you to execute vim commands from lua
+--  It aliases :e $MYVIMRC
+vim.api.nvim_create_user_command("Cfg", function()
+  vim.cmd("e $MYVIMRC") -- vim.cmd allows you to execute vim commands from lua
 end, {})
 
 -- [[ Install `lazy.nvim` plugin manager ]]

--- a/init.lua
+++ b/init.lua
@@ -198,6 +198,16 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   end,
 })
 
+-- [[ Basic user commands ]]
+-- See `:help lua-guide-commands-create`
+
+-- Quickly jump to your config with this awesome custom command
+-- Try it by starting nvim in a random directory and typing :Config
+vim.api.nvim_create_user_command("Config", function()
+  local path = "~/.config/nvim/" -- You can customize the path here
+  vim.cmd("e" .. path)           -- vim.cmd allows you to execute vim commands from lua
+end, {})
+
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
 local lazypath = vim.fn.stdpath 'data' .. '/lazy/lazy.nvim'
@@ -232,7 +242,7 @@ require('lazy').setup {
   --    require('Comment').setup({})
 
   -- "gc" to comment visual regions/lines
-  { 'numToStr/Comment.nvim', opts = {} },
+  { 'numToStr/Comment.nvim',    opts = {} },
 
   -- Here is a more advanced example where we pass configuration
   -- options to `gitsigns.nvim`. This is equivalent to the following lua:
@@ -267,7 +277,7 @@ require('lazy').setup {
   -- after the plugin has been loaded:
   --  config = function() ... end
 
-  { -- Useful plugin to show you pending keybinds.
+  {                     -- Useful plugin to show you pending keybinds.
     'folke/which-key.nvim',
     event = 'VeryLazy', -- Sets the loading event to 'VeryLazy'
     config = function() -- This is the function that runs, AFTER loading
@@ -722,7 +732,7 @@ require('lazy').setup {
     --
     -- If you want to see what colorschemes are already installed, you can use `:Telescope colorscheme`
     'folke/tokyonight.nvim',
-    lazy = false, -- make sure we load this during startup if it is your main colorscheme
+    lazy = false,    -- make sure we load this during startup if it is your main colorscheme
     priority = 1000, -- make sure to load this before all the other start plugins
     config = function()
       -- Load the colorscheme here


### PR DESCRIPTION
**Summary**
This PR adds a custom user command in kickstart.nvim as well as comments explaining how to create such commands and where to find help.
This command is `:Config`, which just switches the current buffer to the user's config.

**Why?**
Kickstart is aimed at beginners, and when you're a beginner you modify your config a lot. And you encounter problems a lot. When that happens, it can be cumbersome to cd to your config directory everytime an error pops up. A simple command such as `Config` (or `Cfg` as I use myself) allows newbies to switch to their config when an error pops up, save quand quit, restart neovim and go on with their work. 

**Possible improvements**
I currently only `:e` the path to the config, which doesn't change the current working directory. We might want to use `:cd` so users can edit multiple files in their config using netrw or telescope.