### PR TITLE
fix: checkhealth reported nvim version

### DIFF
--- a/lua/kickstart/health.lua
+++ b/lua/kickstart/health.lua
@@ -6,15 +6,16 @@
 --]]
 
 local check_version = function()
+  local verstr = string.format('%s.%s.%s', vim.version().major, vim.version().minor, vim.version().patch)
   if not vim.version.cmp then
-    vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", tostring(vim.version())))
+    vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
     return
   end
 
   if vim.version.cmp(vim.version(), { 0, 9, 4 }) >= 0 then
-    vim.health.ok(string.format("Neovim version is: '%s'", tostring(vim.version())))
+    vim.health.ok(string.format("Neovim version is: '%s'", verstr))
   else
-    vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", tostring(vim.version())))
+    vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
   end
 end
 


### PR DESCRIPTION
Fixes: nvim-lua/kickstart.nvim#677
Neovim prior to 0.10 does not support `tostring(vim.version())` this resulted in the `:checkhealth` reported version as:
```
- OK Neovim version is: 'table: 0x7f470b340028'
```
With this fix the version is reported properly:
```
- OK Neovim version is: '0.9.5'
```