### PR TITLE
Change statusline location to LINE:COLUMN

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -761,11 +761,11 @@ require('lazy').setup {
       statusline.setup()
 
       -- You can configure sections in the statusline by overriding their
-      -- default behavior. For example, here we disable the section for
-      -- cursor information because line numbers are already enabled
+      -- default behavior. For example, here we set the section for
+      -- cursor location to LINE:COLUMN
       ---@diagnostic disable-next-line: duplicate-set-field
       statusline.section_location = function()
-        return ''
+        return '%2l:%-2v'
       end
 
       -- ... and there is more!


### PR DESCRIPTION
TJ said in the video: (timestamp: 5:32)
https://www.youtube.com/watch?v=m8C0Cq9Uv9o&t=332s
> we try and set some **good defaults** for you for the experience that
> you might expect normally when you open up a random text editor

The LINE:COLUMN format for cursor location is ubiquitous among many
if not all popular editors, it's the default in plain vim, plain neovim,
nvim-lazy, nvim-lunar, nvim-astro and other editors that we
don't mention. All those editors (except plain vim/nvim) also do show
the line numbers. This for sure is the default that a user expects.

If you still don't want to show the cursor location then at least
a comment should be added on how to achieve that. (`'%2l:%-2v'`)
But I'd still argue that making the line:column the default as
it is easier for someone that wants no cursor location
to replace that with an empty string than it is for someone
to figure out how to achieve line:column if the default is empty.
