### PR TITLE
Add separate comment for `timeoutlen` option

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -127,6 +127,9 @@ vim.opt.signcolumn = 'yes'
 
 -- Decrease update time
 vim.opt.updatetime = 250
+
+-- Decrease mapped sequence wait time
+-- Displays which-key popup sooner
 vim.opt.timeoutlen = 300
 
 -- Configure how new splits should be opened


### PR DESCRIPTION
`timeoutlen` option was under unrelated comment with `updatetime` option.