### PR TITLE
conform: autoformat on save only for specified filetypes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -603,10 +603,16 @@ require('lazy').setup({
     'stevearc/conform.nvim',
     opts = {
       notify_on_error = false,
-      format_on_save = {
-        timeout_ms = 500,
-        lsp_fallback = true,
-      },
+      format_on_save = function(bufnr)
+        -- Disable "format_on_save lsp_fallback" for languages that don't
+        -- have a well standardized coding style. You can add additional
+        -- languages here or re-enable it for the disabled ones.
+        local disable_filetypes = { c = true, cpp = true }
+        return {
+          timeout_ms = 500,
+          lsp_fallback = not disable_filetypes[vim.bo[bufnr].filetype],
+        }
+      end,
       formatters_by_ft = {
         lua = { 'stylua' },
         -- Conform can also run multiple formatters sequentially


### PR DESCRIPTION
Fixes: #686

Enable the autoformat on save only for specified filetypes.
By default this is only for lua, similar as LSP is by default only enabled for lua.
Based on conform recipe:
https://github.com/stevearc/conform.nvim/blob/master/doc/recipes.md

In my view having the autoformat on save enabled by default for all filetypes is a bit too intrusive, hence this PR.
