### PR TITLE
Use `cmp-nvim-lua` as `nvim-cmp` source for neovim Lua API

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -629,9 +629,6 @@ require('lazy').setup {
     dependencies = {
       -- Snippet Engine & its associated nvim-cmp source
       {
-        -- nvim-cmp source for neovim Lua API
-        -- so that things like vim.keymap.set, etc. are autocompleted
-        'hrsh7th/cmp-nvim-lua',
         'L3MON4D3/LuaSnip',
         build = (function()
           -- Build Step is needed for regex support in snippets
@@ -650,6 +647,9 @@ require('lazy').setup {
       --  into multiple repos for maintenance purposes.
       'hrsh7th/cmp-nvim-lsp',
       'hrsh7th/cmp-path',
+      -- nvim-cmp source for neovim Lua API
+      -- so that things like vim.keymap.set, etc. are autocompleted
+      'hrsh7th/cmp-nvim-lua',
 
       -- If you want to add a bunch of pre-configured snippets,
       --    you can use this plugin to help you. It even has snippets

--- a/init.lua
+++ b/init.lua
@@ -629,6 +629,9 @@ require('lazy').setup {
     dependencies = {
       -- Snippet Engine & its associated nvim-cmp source
       {
+        -- nvim-cmp source for neovim Lua API
+        -- so that things like vim.keymap.set, etc. are autocompleted
+        'hrsh7th/cmp-nvim-lua',
         'L3MON4D3/LuaSnip',
         build = (function()
           -- Build Step is needed for regex support in snippets
@@ -708,6 +711,7 @@ require('lazy').setup {
           end, { 'i', 's' }),
         },
         sources = {
+          { name = 'nvim_lua' },
           { name = 'nvim_lsp' },
           { name = 'luasnip' },
           { name = 'path' },


### PR DESCRIPTION
Things like `vim.keymap.set` were not autocompleting for me and I thought I heard @tjdevries mention that we should be able to type commands in our config without having to "wing it" unless I missed a later part of the video where this was added and removed, but I think it's very helpful for editing your config

https://github.com/hrsh7th/cmp-nvim-lua/tree/main