### PR TITLE
Replace `vim-sleuth` with `guess-indent.nvim`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -220,7 +220,7 @@ vim.opt.rtp:prepend(lazypath)
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup {
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
-  'tpope/vim-sleuth', -- Detect tabstop and shiftwidth automatically
+  'numToStr/Comment.nvim', -- 'gc' to comment visual regions/lines
 
   -- NOTE: Plugins can also be added by using a table,
   -- with the first argument being the link and the following
@@ -229,10 +229,10 @@ require('lazy').setup {
   -- Use `opts = {}` to force a plugin to be loaded.
   --
   --  This is equivalent to:
-  --    require('Comment').setup({})
+  --    require('guess-indent').setup({})
 
-  -- "gc" to comment visual regions/lines
-  { 'numToStr/Comment.nvim', opts = {} },
+  -- Detect tabstop and shiftwidth automatically
+  { 'NMAC427/guess-indent.nvim', opts = {} },
 
   -- Here is a more advanced example where we pass configuration
   -- options to `gitsigns.nvim`. This is equivalent to the following lua:


### PR DESCRIPTION
[guess-indent.nvim](https://github.com/NMAC427/guess-indent.nvim) is a lua version of `vim-sleuth`. It also has the advantage of having an option to override `.editorconfig`, if needed.

However, it does require a `.setup()` call, so a `opts = {}` will be required, which slightly disturbs the "introductory flow" of kickstart. To keep the introduction working, I placed `Comment.nvim` first (as it does not require a `.setup()` call), and put `guess-indent` second.