### PR TITLE
README.md: add a Nerd Font requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you are experiencing issues, please make sure you have the latest versions.
 External Requirements:
 - Basic utils: `git`, `make`, `unzip`, C Compiler (`gcc`)
 - [ripgrep](https://github.com/BurntSushi/ripgrep#installation)
+- A [Nerd Font](https://www.nerdfonts.com/)
 - Language Setup:
   - If want to write Typescript, you need `npm`
   - If want to write Golang, you will need `go`


### PR DESCRIPTION
Fixes nvim-lua/kickstart.nvim#700
A Nerd Font is required by:
- mini.statusline
- Lazy plugin manager
- Neo-tree.nvim - not enabled by default however instructions on how to add it are in the README