### PR TITLE
Remove Nerd Font requirements for lazy.nvim and mini.statusline

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -218,7 +218,7 @@ vim.opt.rtp:prepend(lazypath)
 --    :Lazy update
 --
 -- NOTE: Here is where you install your plugins.
-require('lazy').setup {
+require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
   'tpope/vim-sleuth', -- Detect tabstop and shiftwidth automatically
 
@@ -758,7 +758,8 @@ require('lazy').setup {
       --  You could remove this setup call if you don't like it,
       --  and try some other statusline plugin
       local statusline = require 'mini.statusline'
-      statusline.setup()
+      -- if you have a Nerd Font, you can set use_icons to true
+      statusline.setup { use_icons = false }
 
       -- You can configure sections in the statusline by overriding their
       -- default behavior. For example, here we set the section for
@@ -815,7 +816,27 @@ require('lazy').setup {
   --  Uncomment the following line and add your plugins to `lua/custom/plugins/*.lua` to get going.
   --    For additional information, see `:help lazy.nvim-lazy.nvim-structuring-your-plugins`
   -- { import = 'custom.plugins' },
-}
+}, {
+  -- Define unicode icons.
+  -- If you have a Nerd Font, you can remove the icons section
+  ui = {
+    icons = {
+      cmd = '⌘',
+      config = '🛠',
+      event = '📅',
+      ft = '📂',
+      init = '⚙',
+      keys = '🗝',
+      plugin = '🔌',
+      runtime = '💻',
+      require = '🌙',
+      source = '📄',
+      start = '🚀',
+      task = '📌',
+      lazy = '💤 ',
+    },
+  },
+})
 
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et


### PR DESCRIPTION
Fixes nvim-lua/kickstart.nvim#700

This has two changes:
- lazy.nvim: use unicode instead of Nerd Font icons.
- mini.statusline: disable icons for git branch, lsp, filetype (filetype icons are only enabled if nvim-web-devicons is also loaded)


For reference, the unicode icons are copied from the suggestion from:
https://github.com/folke/lazy.nvim/blob/aedcd79811d491b60d0a6577a9c1701063c2a609/README.md?plain=1#L473
> If you don't want to use a Nerd Font, you can replace the icons with Unicode symbols.
