### PR TITLE
Use lazy's init instead of disabling lazy loading for tokyonight

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -722,9 +722,8 @@ require('lazy').setup {
     --
     -- If you want to see what colorschemes are already installed, you can use `:Telescope colorscheme`
     'folke/tokyonight.nvim',
-    lazy = false, -- make sure we load this during startup if it is your main colorscheme
     priority = 1000, -- make sure to load this before all the other start plugins
-    config = function()
+    init = function()
       -- Load the colorscheme here.
       -- Like many other themes, this one has different styles, and you could load
       -- any other, such as 'tokyonight-storm', 'tokyonight-moon', or 'tokyonight-day'.


### PR DESCRIPTION
Lazy's init function runs at startup and colorschemes are auto loaded when called so it removes the need of disabling lazy loading.