### PR TITLE
chore: rename <C-T> to <C-t> for consistency

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -456,7 +456,7 @@ require('lazy').setup({
 
           -- Jump to the definition of the word under your cursor.
           --  This is where a variable was first declared, or where a function is defined, etc.
-          --  To jump back, press <C-T>.
+          --  To jump back, press <C-t>.
           map('gd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
 
           -- Find references for the word under your cursor.


### PR DESCRIPTION
So far init.lua lowercased all ``<C-x>`` key mappings. As a vim nob I then assumed that ``<C-T>`` means ctrl+shift+t Because this one was suddenly uppercased.
But seems like the casing is ignored and I had to actually press ctrl+t or is this my terminal emulator messing with me and ctrl+shift+t also works. And ctrl+t is just the fallback because of the ctrl+shift problem with terminal emulators?

```
$ grep -Er '<C-[A-Z]>' init.lua lua/ | wc -l
1

$ grep -Er '<C-[a-z]>' init.lua lua/ | wc -l
12
```

I use gnome BTW