### PR TITLE
Added a customizable highlight on yank. Color and duration can easily…

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -188,18 +188,20 @@ vim.keymap.set('n', '<C-j>', '<C-w><C-j>', { desc = 'Move focus to the lower win
 vim.keymap.set('n', '<C-k>', '<C-w><C-k>', { desc = 'Move focus to the upper window' })
 
 -- [[ Basic Autocommands ]]
---  See `:help lua-guide-autocommands`
 
--- Highlight when yanking (copying) text
---  Try it with `yap` in normal mode
+-- NOTE: Displays a colored highlight when you yank (copy) or delete text in Neovim
+
+-- Choose what color the highlight should be: guibg=#40005b (hexidecimal color code)
+-- Choose how long the highlight appears: timeout=400 (value is in milliseconds)
+vim.api.nvim_exec([[
+  augroup YankHighlight
+    autocmd!
+    autocmd TextYankPost * silent! lua vim.highlight.on_yank {higroup="YankHighlight",timeout=400}
+  augroup END
+  hi YankHighlight guibg=#40005b ctermbg=0
+]], false)
+--  See `:help lua-guide-autocommands`
 --  See `:help vim.highlight.on_yank()`
-vim.api.nvim_create_autocmd('TextYankPost', {
-  desc = 'Highlight when yanking (copying) text',
-  group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
-  callback = function()
-    vim.highlight.on_yank()
-  end,
-})
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
@@ -840,6 +842,7 @@ require('lazy').setup({
     },
   },
 })
+
 
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et


### PR DESCRIPTION
I have changed the highlight on yank auto-command to be more customizable. 

Those who are new to Neovim will be easily able to change the color of the highlight (if they don't like the default orange flash).

They can also shorten or increase how long the highlight appears for.

I've been using this auto command for months now, without any bugs or clashes with UI plugins.