### PR TITLE
Added the options to change default orange color, and duration of the highlight-on-yank autocommand

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -190,14 +190,26 @@ vim.keymap.set('n', '<C-k>', '<C-w><C-k>', { desc = 'Move focus to the upper win
 -- [[ Basic Autocommands ]]
 --  See `:help lua-guide-autocommands`
 
+-- NOTE: Displays colored highlight when you copy or delete text in Neovim
+
 -- Highlight when yanking (copying) text
 --  Try it with `yap` in normal mode
 --  See `:help vim.highlight.on_yank()`
+
+-- Choose your own highlight color: value in hexidecimals
+local highlight_color = "#40005b"
+
+-- Define how long the highlight should appear: value is in milliseconds
+local highlight_timeout = 300
+
+-- Create autocommand for highlighting yanked text
 vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function()
-    vim.highlight.on_yank()
+    -- Set highlight color and timeout
+    vim.cmd(string.format("highlight YankHighlight guibg=%s ctermbg=0", highlight_color))
+    vim.highlight.on_yank({ higroup = "YankHighlight", timeout = highlight_timeout })
   end,
 })
 
@@ -235,7 +247,7 @@ require('lazy').setup({
   --    require('Comment').setup({})
 
   -- "gc" to comment visual regions/lines
-  { 'numToStr/Comment.nvim', opts = {} },
+  { 'numToStr/Comment.nvim',    opts = {} },
 
   -- Here is a more advanced example where we pass configuration
   -- options to `gitsigns.nvim`. This is equivalent to the following lua:
@@ -270,7 +282,7 @@ require('lazy').setup({
   -- after the plugin has been loaded:
   --  config = function() ... end
 
-  { -- Useful plugin to show you pending keybinds.
+  {                     -- Useful plugin to show you pending keybinds.
     'folke/which-key.nvim',
     event = 'VimEnter', -- Sets the loading event to 'VimEnter'
     config = function() -- This is the function that runs, AFTER loading
@@ -316,7 +328,7 @@ require('lazy').setup({
       { 'nvim-telescope/telescope-ui-select.nvim' },
 
       -- Useful for getting pretty icons, but requires a Nerd Font.
-      { 'nvim-tree/nvim-web-devicons', enabled = vim.g.have_nerd_font },
+      { 'nvim-tree/nvim-web-devicons',            enabled = vim.g.have_nerd_font },
     },
     config = function()
       -- Telescope is a fuzzy finder that comes with a lot of different things that
@@ -723,7 +735,7 @@ require('lazy').setup({
     --
     -- If you want to see what colorschemes are already installed, you can use `:Telescope colorscheme`
     'folke/tokyonight.nvim',
-    lazy = false, -- make sure we load this during startup if it is your main colorscheme
+    lazy = false,    -- make sure we load this during startup if it is your main colorscheme
     priority = 1000, -- make sure to load this before all the other start plugins
     config = function()
       -- Load the colorscheme here.


### PR DESCRIPTION
Those who are new to Neovim will be easily able to change the color of the highlight (if they don't like the default orange flash).

There are two local variables that can be used to change the color of the highlight and the duration of the highlight.

I've been using this auto command for months now, without any bugs or clashes with UI plugins.

I've tried to keep this as close to lua as possible, while making sure that this pull request is properly formatted using stylua