### PR TITLE
feat: allow treesitter default options to be overwritten by user preferences

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -780,17 +780,18 @@ require('lazy').setup({
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
-    config = function()
+    opts = {
+      ensure_installed = { 'bash', 'c', 'html', 'lua', 'markdown', 'vim', 'vimdoc' },
+      -- Autoinstall languages that are not installed
+      auto_install = true,
+      highlight = { enable = true },
+      indent = { enable = true },
+    },
+    config = function(_, opts)
       -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 
       ---@diagnostic disable-next-line: missing-fields
-      require('nvim-treesitter.configs').setup {
-        ensure_installed = { 'bash', 'c', 'html', 'lua', 'markdown', 'vim', 'vimdoc' },
-        -- Autoinstall languages that are not installed
-        auto_install = true,
-        highlight = { enable = true },
-        indent = { enable = true },
-      }
+      require('nvim-treesitter.configs').setup(opts)
 
       -- There are additional nvim-treesitter modules that you can use to interact
       -- with nvim-treesitter. You should go explore a few and see what interests you:


### PR DESCRIPTION
If we move the default options for treesitter to opts you could then overwite them based on your preferences without altering the default config by doing something like this:

```lua
-- lua/custom/plugins/treesitter.lua

return {
  {
    'nvim-treesitter/nvim-treesitter',
    opts = {
      -- add your own config options here
      ensure_installed = { 'css', 'javascript', 'styled' },
    }
  }
}
```