### PR TITLE
README.md: update neo-tree example - remove legacy setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,6 @@ This will install the tree plugin and add the command `:Neotree` for you. For mo
 In the file: `lua/custom/plugins/filetree.lua`, add:
 
 ```lua
--- Unless you are still migrating, remove the deprecated commands from v1.x
-vim.cmd([[ let g:neo_tree_remove_legacy_commands = 1 ]])
-
 return {
   "nvim-neo-tree/neo-tree.nvim",
   version = "*",


### PR DESCRIPTION
Remove the `g:neo_tree_remove_legacy_commands=1` setting from the example neo-tree plugin in the README.md. This setting has been removed from neo-tree a long ago (Jul 2023): https://github.com/nvim-neo-tree/neo-tree.nvim/commit/78d2616

> Author: cseickel <cseickel@gmail.com>
> Date:   Fri Jul 14 14:12:20 2023 -0400
>
>    feat!: remove deprecated user commands (#1055)
>
>    BREAKING CHANGE: All `NeoTree*` commands have been removed, use `Neotree <args>` instead.