### PR TITLE
Add <C-u>/<C-d> cmp mapping to scroll cmp docs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -680,8 +680,8 @@ require('lazy').setup({
           ['<C-p>'] = cmp.mapping.select_prev_item(),
 
           -- scroll [u]p and [d]own the documentation window
-		      ["<C-u>"] = cmp.mapping.scroll_docs(-4),
-		      ["<C-d>"] = cmp.mapping.scroll_docs(4),
+	  ["<C-u>"] = cmp.mapping.scroll_docs(-4),
+	  ["<C-d>"] = cmp.mapping.scroll_docs(4),
 
           -- Accept ([y]es) the completion.
           --  This will auto-import if your LSP supports it.

--- a/init.lua
+++ b/init.lua
@@ -679,9 +679,8 @@ require('lazy').setup({
           -- Select the [p]revious item
           ['<C-p>'] = cmp.mapping.select_prev_item(),
 
-          -- scroll documentation window up
+          -- scroll the documentation window [b]ack / [f]orward
           ['<C-b>'] = cmp.mapping.scroll_docs(-4),
-          -- scroll documentation window down
           ['<C-f>'] = cmp.mapping.scroll_docs(4),
 
           -- Accept ([y]es) the completion.

--- a/init.lua
+++ b/init.lua
@@ -679,8 +679,9 @@ require('lazy').setup({
           -- Select the [p]revious item
           ['<C-p>'] = cmp.mapping.select_prev_item(),
 
-          -- scroll [u]p and [d]own the documentation window
+          -- scroll documentation window up
           ['<C-b>'] = cmp.mapping.scroll_docs(-4),
+          -- scroll documentation window down
           ['<C-f>'] = cmp.mapping.scroll_docs(4),
 
           -- Accept ([y]es) the completion.

--- a/init.lua
+++ b/init.lua
@@ -680,8 +680,8 @@ require('lazy').setup({
           ['<C-p>'] = cmp.mapping.select_prev_item(),
 
           -- scroll [u]p and [d]own the documentation window
-	  ["<C-u>"] = cmp.mapping.scroll_docs(-4),
-	  ["<C-d>"] = cmp.mapping.scroll_docs(4),
+          ['<C-b>'] = cmp.mapping.scroll_docs(-4),
+          ['<C-f>'] = cmp.mapping.scroll_docs(4),
 
           -- Accept ([y]es) the completion.
           --  This will auto-import if your LSP supports it.

--- a/init.lua
+++ b/init.lua
@@ -679,6 +679,10 @@ require('lazy').setup({
           -- Select the [p]revious item
           ['<C-p>'] = cmp.mapping.select_prev_item(),
 
+          -- scroll [u]p and [d]own the documentation window
+		      ["<C-u>"] = cmp.mapping.scroll_docs(-4),
+		      ["<C-d>"] = cmp.mapping.scroll_docs(4),
+
           -- Accept ([y]es) the completion.
           --  This will auto-import if your LSP supports it.
           --  This will expand snippets if the LSP sent a snippet.


### PR DESCRIPTION
I have added control-u and control-d to scroll the auto completion window up and down respectively.

For the average new kickstart user, this will give them  the ability to scroll documentation without a mouse and keyboard.

I am fond of reading documentation from the autocomplete window and being able to scroll the window without a mouse is a must have for my setup, I believe it may be the same for many others.