### PR TITLE
Added folke/neodev.nvim for proper nvim api completion and annotation

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -410,6 +410,10 @@ require('lazy').setup({
       -- Useful status updates for LSP.
       -- NOTE: `opts = {}` is the same as calling `require('fidget').setup({})`
       { 'j-hui/fidget.nvim', opts = {} },
+
+      -- `neodev` configures Lua LSP for your Neovim config, runtime and plugins
+      -- used for completion, annotations and signatures of Neovim apis
+      { 'folke/neodev.nvim', opts = {} },
     },
     config = function()
       -- Brief Aside: **What is LSP?**
@@ -551,18 +555,6 @@ require('lazy').setup({
           -- capabilities = {},
           settings = {
             Lua = {
-              runtime = { version = 'LuaJIT' },
-              workspace = {
-                checkThirdParty = false,
-                -- Tells lua_ls where to find all the Lua files that you have loaded
-                -- for your neovim configuration.
-                library = {
-                  '${3rd}/luv/library',
-                  unpack(vim.api.nvim_get_runtime_file('', true)),
-                },
-                -- If lua_ls is really slow on your computer, you can try this instead:
-                -- library = { vim.env.VIMRUNTIME },
-              },
               completion = {
                 callSnippet = 'Replace',
               },


### PR DESCRIPTION
Fixes nvim-lua/kickstart.nvim#692

`neodev` configures Lua LSP for your Neovim config, runtime and plugins used for completion, annotations and signatures of Neovim apis

With neodev, there's no more need to manually set lua_ls workspace settings which don't seem to work properly anyway as currently nvim api completion does not work.