### PR TITLE
Move friendly snippets to dependencies of LuaSnip

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -632,6 +632,13 @@ require('lazy').setup({
           end
           return 'make install_jsregexp'
         end)(),
+        dependencies = {
+          -- If you want to add a bunch of pre-configured snippets,
+          --    you can use this plugin to help you. It even has snippets
+          --    for various frameworks/libraries/etc. but you will have to
+          --    set up the ones that are useful for you.
+          -- 'rafamadriz/friendly-snippets',
+        },
       },
       'saadparwaiz1/cmp_luasnip',
 
@@ -640,12 +647,6 @@ require('lazy').setup({
       --  into multiple repos for maintenance purposes.
       'hrsh7th/cmp-nvim-lsp',
       'hrsh7th/cmp-path',
-
-      -- If you want to add a bunch of pre-configured snippets,
-      --    you can use this plugin to help you. It even has snippets
-      --    for various frameworks/libraries/etc. but you will have to
-      --    set up the ones that are useful for you.
-      -- 'rafamadriz/friendly-snippets',
     },
     config = function()
       -- See `:help cmp`

--- a/init.lua
+++ b/init.lua
@@ -637,7 +637,12 @@ require('lazy').setup({
           --    you can use this plugin to help you. It even has snippets
           --    for various frameworks/libraries/etc. but you will have to
           --    set up the ones that are useful for you.
-          -- 'rafamadriz/friendly-snippets',
+          -- {
+          --   'rafamadriz/friendly-snippets',
+          --   config = function()
+          --     require('luasnip.loaders.from_vscode').lazy_load()
+          --   end,
+          -- },
         },
       },
       'saadparwaiz1/cmp_luasnip',

--- a/init.lua
+++ b/init.lua
@@ -633,10 +633,9 @@ require('lazy').setup({
           return 'make install_jsregexp'
         end)(),
         dependencies = {
-          -- If you want to add a bunch of pre-configured snippets,
-          --    you can use this plugin to help you. It even has snippets
-          --    for various frameworks/libraries/etc. but you will have to
-          --    set up the ones that are useful for you.
+          -- `friendly-snippets` contains a variety of premade snippets.
+          --    See the README about individual language/framework/plugin snippets:
+          --    https://github.com/rafamadriz/friendly-snippets
           -- {
           --   'rafamadriz/friendly-snippets',
           --   config = function()


### PR DESCRIPTION
As the friendly-snippets docs say:
> Warning: If you're using LuaSnip make sure to use require("luasnip.loaders.from_vscode").lazy_load(), and add friendly-snippets as a dependency for LuaSnip, otherwise snippets might not be detected. If you don't use lazy_load() you might notice a slower startup-time