### PR TITLE
Fix check health

### DIFF
--- a/lua/kickstart/health.lua
+++ b/lua/kickstart/health.lua
@@ -8,14 +8,14 @@
 local check_version = function()
   local verstr = string.format('%s.%s.%s', vim.version().major, vim.version().minor, vim.version().patch)
   if not vim.version.cmp then
-    vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
+    vim.health.report_error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
     return
   end
 
-  if vim.version.cmp(vim.version(), { 0, 9, 4 }) >= 0 then
-    vim.health.ok(string.format("Neovim version is: '%s'", verstr))
+  if vim.version.cmp(verstr, '0.9.4') >= 0 then
+    vim.health.report_ok(string.format("Neovim version is: '%s'", verstr))
   else
-    vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
+    vim.health.report_error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
   end
 end
 
@@ -24,9 +24,9 @@ local check_external_reqs = function()
   for _, exe in ipairs { 'git', 'make', 'unzip', 'rg' } do
     local is_executable = vim.fn.executable(exe) == 1
     if is_executable then
-      vim.health.ok(string.format("Found executable: '%s'", exe))
+      vim.health.report_ok(string.format("Found executable: '%s'", exe))
     else
-      vim.health.warn(string.format("Could not find executable: '%s'", exe))
+      vim.health.report_warn(string.format("Could not find executable: '%s'", exe))
     end
   end
 
@@ -35,16 +35,16 @@ end
 
 return {
   check = function()
-    vim.health.start 'kickstart.nvim'
+    vim.health.report_start 'kickstart.nvim'
 
-    vim.health.info [[NOTE: Not every warning is a 'must-fix' in `:checkhealth`
+    vim.health.report_info [[NOTE: Not every warning is a 'must-fix' in `:checkhealth`
 
   Fix only warnings for plugins and languages you intend to use.
     Mason will give warnings for languages that are not installed.
     You do not need to install, unless you want to use those languages!]]
 
     local uv = vim.uv or vim.loop
-    vim.health.info('System Information: ' .. vim.inspect(uv.os_uname()))
+    vim.health.report_info('System Information: ' .. vim.inspect(uv.os_uname()))
 
     check_version()
     check_external_reqs()


### PR DESCRIPTION
On nvim v0.9.5 when trying to run `:checkhealth` I kept getting lua errors from kickstart

1. the `vim.health....` functions should all start with `report_`, help results for `vim.health`: 
![image](https://github.com/nvim-lua/kickstart.nvim/assets/154016947/d080d324-b7a9-4225-817c-c58ee490a08e)

1. `vim.version.cmp` expects 2 strings but was getting 2 tables:
![image](https://github.com/nvim-lua/kickstart.nvim/assets/154016947/0b367274-9825-44ad-a8a7-f1bc1957e363)

Not sure if this are correct fixes, this is what I had to do to make `:checkhealth` pass.