### PR TITLE
assign table to filetype in lua_ls config comment

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -554,7 +554,7 @@ require('lazy').setup({
 
         lua_ls = {
           -- cmd = {...},
-          -- filetypes { ...},
+          -- filetypes = { ...},
           -- capabilities = {},
           settings = {
             Lua = {


### PR DESCRIPTION
In `init.lua` uncommenting `-- filetypes { ...}` and adding some file types
(e.g., `filetypes { "lua" }` yields an error because the table is not assigned
and `filetypes` remains undefined.

That could be confusing to someone starting out and this fix changes the
(commented) line to `-- filetypes = { ...}` to prevent that specific error after
uncommenting.