### PR TITLE
Add gitsigns essential keymaps

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -255,6 +255,33 @@ require('lazy').setup({
         topdelete = { text = '‾' },
         changedelete = { text = '~' },
       },
+      on_attach = function(bufnr)
+        -- Include essential gitsigns keymaps, for more see gitsigns README:
+        -- https://github.com/lewis6991/gitsigns.nvim
+        local gs = package.loaded.gitsigns
+        local function map(mode, l, r, opts)
+          opts = opts or {}
+          opts.buffer = bufnr
+          vim.keymap.set(mode, l, r, opts)
+        end
+        -- Navigation
+        map({ 'n', 'v' }, ']c', gs.next_hunk, { desc = 'Jump to next git [c]hange' })
+        map({ 'n', 'v' }, '[c', gs.prev_hunk, { desc = 'Jump to previous git [c]hange' })
+        -- Actions
+        map('n', '<leader>hs', gs.stage_hunk, { desc = 'git [s]tage hunk' })
+        map('n', '<leader>hr', gs.reset_hunk, { desc = 'git [r]eset hunk' })
+        map('n', '<leader>hu', gs.undo_stage_hunk, { desc = 'git [u]ndo stage hunk' })
+        map('n', '<leader>hp', gs.preview_hunk, { desc = 'git [p]review hunk' })
+        map('n', '<leader>hb', gs.blame_line, { desc = 'git [b]lame line' })
+        map('n', '<leader>hd', gs.diffthis, { desc = 'git [d]iff against index' })
+        -- Visual mode
+        map('v', '<leader>hs', function()
+          gs.stage_hunk { vim.fn.line '.', vim.fn.line 'v' }
+        end, { desc = 'stage git hunk' })
+        map('v', '<leader>hr', function()
+          gs.reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
+        end, { desc = 'reset git hunk' })
+      end,
     },
   },
 
@@ -287,7 +314,12 @@ require('lazy').setup({
         ['<leader>s'] = { name = '[S]earch', _ = 'which_key_ignore' },
         ['<leader>w'] = { name = '[W]orkspace', _ = 'which_key_ignore' },
         ['<leader>t'] = { name = '[T]oggle', _ = 'which_key_ignore' },
+        ['<leader>h'] = { name = 'Git [H]unk', _ = 'which_key_ignore' },
       }
+      -- visual mode
+      require('which-key').register({
+        ['<leader>h'] = { 'Git [H]unk' },
+      }, { mode = 'v' })
     end,
   },
 


### PR DESCRIPTION
An alternative attempt at including only the essential keymaps compared to the full list in: https://github.com/nvim-lua/kickstart.nvim/pull/740
Changes compared to the full list:
- reduced the list of keymaps as suggested by @lewis6991 (the author of gitsigns):
  https://github.com/nvim-lua/kickstart.nvim/pull/740#pullrequestreview-1948295290
- simplified navigation keymap code - verified that it works also in diff mode, the only difference is a slight change in behaviour as gitsigns navigation does wrap-around while original diff mode does not. Also confirmed with @lewis6991 that it should work.
- Added a note pointing to gitsigns README for the full list of keymaps

Compared to the original PR this one has about half the lines of code, hopefully this will make it more likely to be included.
