### PR TITLE
[fix #799] Add `luadoc` to `ensure_installed` List of `nvim-treesitter/nvim-treesitter`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -791,7 +791,7 @@ require('lazy').setup({
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
     opts = {
-      ensure_installed = { 'bash', 'c', 'html', 'lua', 'markdown', 'vim', 'vimdoc' },
+      ensure_installed = { 'bash', 'c', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
       -- Autoinstall languages that are not installed
       auto_install = true,
       highlight = {


### PR DESCRIPTION
Add `'luadoc'`, to the `ensure_installed` of `nvim-treesitter/nvim-treesitter`, fixes #799.