### PR TITLE
Add LSP keymap to format current buffer

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -501,6 +501,11 @@ require('lazy').setup({
           --  For example, in C this would take you to the header.
           map('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
 
+          -- Formats the current buffer
+          map('<space>f', function()
+            vim.lsp.buf.format { async = true }
+          end, '[F]ormat code')
+
           -- The following two autocommands are used to highlight references of the
           -- word under your cursor when your cursor rests there for a little while.
           --    See `:help CursorHold` for information about when this is executed

--- a/init.lua
+++ b/init.lua
@@ -502,7 +502,7 @@ require('lazy').setup({
           map('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
 
           -- Formats the current buffer
-          map('<space>f', function()
+          map('<leader>f', function()
             vim.lsp.buf.format { async = true }
           end, '[F]ormat code')
 


### PR DESCRIPTION
Having a key map to format the current buffer seems like something that is useful and general enough to have in the kickstart config, so I'm proposing this addition here

Feel free to close if you think that this is not true, though 🙏🏼 