### PR TITLE
Don't lazy load conform plugin

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -600,6 +600,7 @@ require('lazy').setup({
 
   { -- Autoformat
     'stevearc/conform.nvim',
+    lazy = false,
     keys = {
       {
         '<leader>f',


### PR DESCRIPTION
My last commit needs an additional fix:

The recent addition of the keys field in the lazy plugin spec for conform has turned the plugin to be lazy loaded on the configured keymap. This inadvertently broke the default "format on save" behaviour. Setting the lazy flag explicitly to false restores the original behaviour. (and keeps the keymap working as well)

I apologize for not noticing this before, my testing was not thorough enough.
