### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+***************************************************************************
+**NOTE**
+Please verify that the `base repository` above has the intended destination!
+Github by default opens Pull Requests against the parent of a forked repository.
+If this is your personal fork and you didn't intend to open a PR for contribution
+to the original project then adjust the `base repository` accordingly.
+**************************************************************************
+


### PR DESCRIPTION
Add a github pull request template, which might help prevent accidental pull requests by users that use a forked repo for personal use. This text will be inserted in the description form of the PR page.

If you agree with this approach please check the wording and let me know if you want to formulate it differently.
