### PR TITLE
Enable inlay hints for the supporting servers

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -286,6 +286,7 @@ require('lazy').setup({
         ['<leader>r'] = { name = '[R]ename', _ = 'which_key_ignore' },
         ['<leader>s'] = { name = '[S]earch', _ = 'which_key_ignore' },
         ['<leader>w'] = { name = '[W]orkspace', _ = 'which_key_ignore' },
+        ['<leader>t'] = { name = '[T]oggle', _ = 'which_key_ignore' },
       }
     end,
   },

--- a/init.lua
+++ b/init.lua
@@ -518,6 +518,16 @@ require('lazy').setup({
               callback = vim.lsp.buf.clear_references,
             })
           end
+
+          -- The following autocommand is used to enable inlay hints in your
+          -- code, if the language server you are using supports them
+          --
+          -- This may be unwanted, since they displace some of your code
+          if client and client.server_capabilities.inlayHintProvider and vim.lsp.inlay_hint then
+            map('<leader>th', function()
+              vim.lsp.inlay_hint.enable(0, not vim.lsp.inlay_hint.is_enabled())
+            end, '[T]oggle Inlay [H]ints')
+          end
         end,
       })
 


### PR DESCRIPTION
Since latest neovim nightly supports inlay hints maybe you should look into enabling them by default, like vscode does.

This can be an unwanted change for some people, since the implemented hints are in the middle of the code and I know some people that don't like that.

Maybe that can be left in, but commented out so the users may know that this feature is supported, just not enabled by default.
