### PR TITLE
Fix: #847 - add prefer_git to treesitter config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -817,6 +817,7 @@ require('lazy').setup({
     config = function(_, opts)
       -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 
+      require('nvim-treesitter.install').prefer_git = true
       ---@diagnostic disable-next-line: missing-fields
       require('nvim-treesitter.configs').setup(opts)
 

--- a/init.lua
+++ b/init.lua
@@ -817,6 +817,7 @@ require('lazy').setup({
     config = function(_, opts)
       -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 
+      -- Prefer git instead of curl in order to improve connectivity in some environments
       require('nvim-treesitter.install').prefer_git = true
       ---@diagnostic disable-next-line: missing-fields
       require('nvim-treesitter.configs').setup(opts)


### PR DESCRIPTION
This PR configures Treesitter to prefer git rather than expecting curl to be installed. This prevevents a failure mode on WSL where curl is optional.

(Doing this small PR on the main fork because my fork is far too far diverged to be able to source a minor change like this, an y'all don't want my 9000 partially blind guy enhancements :)
