### PR TITLE
Fix highlight errors when lsp crash or stop

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -542,9 +542,12 @@ require('lazy').setup({
 
       vim.api.nvim_create_autocmd('LspDetach', {
         group = vim.api.nvim_create_augroup('kickstart-lsp-detach', { clear = true }),
-        callback = function()
+        callback = function(event)
           vim.lsp.buf.clear_references()
-          vim.api.nvim_del_augroup_by_name 'kickstart-lsp-highlight'
+          local cmds = vim.api.nvim_get_autocmds { group = 'kickstart-lsp-highlight', buffer = event.buf }
+          for _, cmd in ipairs(cmds) do
+            vim.api.nvim_del_autocmd(cmd.id)
+          end
         end,
       })
 

--- a/init.lua
+++ b/init.lua
@@ -544,10 +544,7 @@ require('lazy').setup({
         group = vim.api.nvim_create_augroup('kickstart-lsp-detach', { clear = true }),
         callback = function(event)
           vim.lsp.buf.clear_references()
-          local cmds = vim.api.nvim_get_autocmds { group = 'kickstart-lsp-highlight', buffer = event.buf }
-          for _, cmd in ipairs(cmds) do
-            vim.api.nvim_del_autocmd(cmd.id)
-          end
+          vim.api.nvim_clear_autocmds { group = 'kickstart-lsp-highlight', buffer = event.buf }
         end,
       })
 

--- a/init.lua
+++ b/init.lua
@@ -516,12 +516,23 @@ require('lazy').setup({
           if client and client.server_capabilities.documentHighlightProvider then
             vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
               buffer = event.buf,
-              callback = vim.lsp.buf.document_highlight,
+              callback = function()
+                if not vim.lsp.get_client_by_id(event.data.client_id) then
+                  vim.lsp.buf.clear_references()
+                  return true
+                end
+                vim.lsp.buf.document_highlight()
+              end,
             })
 
             vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
               buffer = event.buf,
-              callback = vim.lsp.buf.clear_references,
+              callback = function()
+                if not vim.lsp.get_client_by_id(event.data.client_id) then
+                  return true
+                end
+                vim.lsp.buf.clear_references()
+              end,
             })
           end
 

--- a/init.lua
+++ b/init.lua
@@ -514,25 +514,17 @@ require('lazy').setup({
           -- When you move your cursor, the highlights will be cleared (the second autocommand).
           local client = vim.lsp.get_client_by_id(event.data.client_id)
           if client and client.server_capabilities.documentHighlightProvider then
+            local highlight_augroup = vim.api.nvim_create_augroup('kickstart-lsp-highlight', { clear = true })
             vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
               buffer = event.buf,
-              callback = function()
-                if not vim.lsp.get_client_by_id(event.data.client_id) then
-                  vim.lsp.buf.clear_references()
-                  return true
-                end
-                vim.lsp.buf.document_highlight()
-              end,
+              group = highlight_augroup,
+              callback = vim.lsp.buf.document_highlight,
             })
 
             vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
               buffer = event.buf,
-              callback = function()
-                if not vim.lsp.get_client_by_id(event.data.client_id) then
-                  return true
-                end
-                vim.lsp.buf.clear_references()
-              end,
+              group = highlight_augroup,
+              callback = vim.lsp.buf.clear_references,
             })
           end
 
@@ -545,6 +537,14 @@ require('lazy').setup({
               vim.lsp.inlay_hint.enable(0, not vim.lsp.inlay_hint.is_enabled())
             end, '[T]oggle Inlay [H]ints')
           end
+        end,
+      })
+
+      vim.api.nvim_create_autocmd('LspDetach', {
+        group = vim.api.nvim_create_augroup('kickstart-lsp-detach', { clear = true }),
+        callback = function()
+          vim.lsp.buf.clear_references()
+          vim.api.nvim_del_augroup_by_name 'kickstart-lsp-highlight'
         end,
       })
 


### PR DESCRIPTION
It adds a check wether the client is still available before highlighting.

If the client is not there anymore it returns true to unregister the autocommand

This fix the
`method textDocument/documentHighlight is not supported by any of the servers registered for the current buffer` errors when doing a LspRestart or the server crashes


