### PR TITLE
fix: restore Mason config timing for DAP startup (again)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -412,7 +412,7 @@ require('lazy').setup({
     'neovim/nvim-lspconfig',
     dependencies = {
       -- Automatically install LSPs and related tools to stdpath for Neovim
-      'williamboman/mason.nvim',
+      { 'williamboman/mason.nvim', config = true }, -- NOTE: Must be loaded before dependants
       'williamboman/mason-lspconfig.nvim',
       'WhoIsSethDaniel/mason-tool-installer.nvim',
 


### PR DESCRIPTION
Addresses regression of issue #554 fixed in #555 but later reintroduced in 8b5d48a and adds note to prevent regression from occurring for a third time.