### PR TITLE
Fix deprecation notice of inlay hints

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -531,7 +531,7 @@ require('lazy').setup({
           -- This may be unwanted, since they displace some of your code
           if client and client.server_capabilities.inlayHintProvider and vim.lsp.inlay_hint then
             map('<leader>th', function()
-              vim.lsp.inlay_hint.enable(0, not vim.lsp.inlay_hint.is_enabled())
+              vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
             end, '[T]oggle Inlay [H]ints')
           end
         end,


### PR DESCRIPTION
Neovim nightly has changed the API for inlay hints.

