### PR TITLE
fix: highlight group clear on each attach

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -514,7 +514,7 @@ require('lazy').setup({
           -- When you move your cursor, the highlights will be cleared (the second autocommand).
           local client = vim.lsp.get_client_by_id(event.data.client_id)
           if client and client.server_capabilities.documentHighlightProvider then
-            local highlight_augroup = vim.api.nvim_create_augroup('kickstart-lsp-highlight', { clear = true })
+            local highlight_augroup = vim.api.nvim_create_augroup('kickstart-lsp-highlight', { clear = false })
             vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
               buffer = event.buf,
               group = highlight_augroup,


### PR DESCRIPTION
In my other pull request when opening a 2 buffers it would clear the whole group and removing the commands for other buffers.

It was an oversight on my part. and I introduced an unwanted side effect.  
