### PR TITLE
Remove nvim-treesitter prefer_git

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -850,8 +850,6 @@ require('lazy').setup({
     config = function(_, opts)
       -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 
-      -- Prefer git instead of curl in order to improve connectivity in some environments
-      require('nvim-treesitter.install').prefer_git = true
       ---@diagnostic disable-next-line: missing-fields
       require('nvim-treesitter.configs').setup(opts)
 


### PR DESCRIPTION
My `~/.config/nvim` is in a git submodule, and starting up neovim from within `~/.config/nvim` with the latest kickstart.nvim init.lua with prefer_git set to true seems to have broken my local git repo. I'm now getting "fatal: unable to read ..." errors, so I have to reinitialize the submodule from scratch to fix it.