### PR TITLE
Remove treesitter auto_install

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -836,8 +836,6 @@ require('lazy').setup({
     build = ':TSUpdate',
     opts = {
       ensure_installed = { 'bash', 'c', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
-      -- Autoinstall languages that are not installed
-      auto_install = true,
       highlight = {
         enable = true,
         -- Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.


### PR DESCRIPTION
It seems like some of the treesitter language are not ready for general use. In my case, Running `git commit -v` resulted in the `gitcommit` language being installed, which resulted in no syntax highlighting at all in the diff below the commit message.