### PR TITLE
Add `diff` to treesitter's `ensure_installed` languages

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -835,7 +835,7 @@ require('lazy').setup({
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
     opts = {
-      ensure_installed = { 'bash', 'c', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
+      ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
       -- Autoinstall languages that are not installed
       auto_install = true,
       highlight = {


### PR DESCRIPTION
This enables highlighted diffs when running `git commit --verbose`.

I think this is a good default for kickstart.nvim since most developers use git regardless of what programming language they normally work in (and we already install gitsigns). This avoids the need for users to manually run `:TSInstall diff` as stated in https://github.com/nvim-lua/kickstart.nvim/issues/237#issuecomment-1493519287.

Before:

![image](https://github.com/nvim-lua/kickstart.nvim/assets/1863540/5cdeab24-b3ed-49bf-838d-8d57eb1984c1)

After:

![image](https://github.com/nvim-lua/kickstart.nvim/assets/1863540/f1987483-08a8-4aec-b1f8-d078988af9e2)