### PR TITLE
Fix neo-tree keymap description

### DIFF
--- a/lua/kickstart/plugins/neo-tree.lua
+++ b/lua/kickstart/plugins/neo-tree.lua
@@ -11,7 +11,7 @@ return {
   },
   cmd = 'Neotree',
   keys = {
-    { '\\', ':Neotree reveal<CR>', { desc = 'NeoTree reveal' } },
+    { '\\', ':Neotree reveal<CR>', desc = 'NeoTree reveal' },
   },
   opts = {
     filesystem = {


### PR DESCRIPTION
The lazy.nvim keys parameter does not need the `desc` to be inside a table in the way that vim.keymap.set() does. With this fix the keymap description will be properly shown for example in telescope keymap search
