### PR TITLE
added support if nvim extention is being used in vscode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,8 @@
+-- if this file is opened in a vscode, exit from here
+if vim.g.vscode then
+  return
+end
+
 --[[
 
 =====================================================================


### PR DESCRIPTION
[VSCODE neovim extention](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim) pre-requisite is to have `nvim` installed and it opens `nvim's` config by default in vscode.
I use both nvim and vscode depending on my project need.

Some of the nvim's UI does not work well with VSCODE. 

This if-else clause will differentiate if we are using vscode or nvim directly.