### PR TITLE
Enable `smartindent` option for default configuration

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -154,6 +154,9 @@ vim.opt.cursorline = true
 -- Minimal number of screen lines to keep above and below the cursor.
 vim.opt.scrolloff = 10
 
+-- Do automatic indent when starting a new line
+vim.opt.smartindent = true
+
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`
 


### PR DESCRIPTION
This PR enables a pretty useful option that probably exists in most IDE's by default - indentations. 
If you see if that can be useful to be included in `basic` configuration, please merge my PR.
If not, I think it has to be at least mentioned(and commented) in the `basic` configuration.


