### PR TITLE
refactor: replace vim.loop with vim.uv

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -207,7 +207,7 @@ vim.api.nvim_create_autocmd('TextYankPost', {
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
 local lazypath = vim.fn.stdpath 'data' .. '/lazy/lazy.nvim'
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   local lazyrepo = 'https://github.com/folke/lazy.nvim.git'
   vim.fn.system { 'git', 'clone', '--filter=blob:none', '--branch=stable', lazyrepo, lazypath }
 end ---@diagnostic disable-next-line: undefined-field


### PR DESCRIPTION
This PR uses vim.uv instead of the deprecated vim.loop. 

See https://github.com/neovim/neovim/pull/22846 for more info.