### PR TITLE
Remove redundant require

### DIFF
--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -47,7 +47,7 @@ return {
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
         group = lint_augroup,
         callback = function()
-          require('lint').try_lint()
+          lint.try_lint()
         end,
       })
     end,


### PR DESCRIPTION
`lint` is already bound above.

https://github.com/nvim-lua/kickstart.nvim/blob/5aeddfdd5d0308506ec63b0e4f8de33e2a39355f/lua/kickstart/plugins/lint.lua#L7

