### PR TITLE
Replace depreciated vim.diagnostic methods in init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -162,8 +162,8 @@ vim.opt.hlsearch = true
 vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
 
 -- Diagnostic keymaps
-vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, { desc = 'Go to previous [D]iagnostic message' })
-vim.keymap.set('n', ']d', vim.diagnostic.goto_next, { desc = 'Go to next [D]iagnostic message' })
+vim.keymap.set('n', '[d', vim.diagnostic.get_prev, { desc = 'Go to previous [D]iagnostic message' })
+vim.keymap.set('n', ']d', vim.diagnostic.get_next, { desc = 'Go to next [D]iagnostic message' })
 vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, { desc = 'Show diagnostic [E]rror messages' })
 vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })
 


### PR DESCRIPTION
Replaced `vim.diagnostic.goto_next` &  `vim.diagnostic.goto_prev` with their new counterparts:
https://neovim.io/doc/user/diagnostic.html#vim.diagnostic.get_prev()
https://neovim.io/doc/user/diagnostic.html#vim.diagnostic.get_next()