### PR TITLE
Make conform.nvim be lazy-loadable again

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -627,7 +627,8 @@ require('lazy').setup({
 
   { -- Autoformat
     'stevearc/conform.nvim',
-    lazy = false,
+    event = { 'BufWritePre' },
+    cmd = { 'ConformInfo' },
     keys = {
       {
         '<leader>f',


### PR DESCRIPTION
The PR that disabled lazy loading (#818) was to fix plugin not being loaded before write. This sets up lazy.nvim to load conform before write.

