### PR TITLE
Fix comment about `mini.ai` example

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -801,7 +801,7 @@ require('lazy').setup({
       --
       -- Examples:
       --  - va)  - [V]isually select [A]round [)]paren
-      --  - yinq - [Y]ank [I]nside [N]ext [']quote
+      --  - yinq - [Y]ank [I]nside [N]ext [Q]uote
       --  - ci'  - [C]hange [I]nside [']quote
       require('mini.ai').setup { n_lines = 500 }
 


### PR DESCRIPTION
Addresses https://github.com/nvim-lua/kickstart.nvim/pull/982#discussion_r1641975175

This example wasn't using `'` so this makes more sense