### PR TITLE
feat: add query parser to treesitter config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -835,7 +835,7 @@ require('lazy').setup({
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
     opts = {
-      ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
+      ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc', 'query' },
       -- Autoinstall languages that are not installed
       auto_install = true,
       highlight = {


### PR DESCRIPTION
Based on the [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#modules) README.md which states query as one of the five parsers that should always be installed.

