### PR TITLE
Add dependencies to neovim/nvim-lspconfig

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -423,6 +423,14 @@ require('lazy').setup({
       -- `neodev` configures Lua LSP for your Neovim config, runtime and plugins
       -- used for completion, annotations and signatures of Neovim apis
       { 'folke/neodev.nvim', opts = {} },
+<<<<<<< Updated upstream
+      'hrsh7th/cmp-nvim-lsp',   
+=======
+
+      'hrsh7th/cmp-nvim-lsp',
+      'hrsh7th/cmp-path',
+      'hrsh7th/nvim-cmp',
+>>>>>>> Stashed changes
     },
     config = function()
       -- Brief aside: **What is LSP?**


### PR DESCRIPTION
I was adding one plugin at the time and noticed that Lazy could not load `neovim/nvim-lspconfig` because it was missing  hrsh7th's cmp-nvim-lsp, cmp-path, nvim-cmp.


PS: Thanks for a great Neovim resource!