### PR TITLE
Remove 'K' mapping

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -498,10 +498,6 @@ require('lazy').setup({
           -- or a suggestion from your LSP for this to activate.
           map('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction')
 
-          -- Opens a popup that displays documentation about the word under your cursor
-          --  See `:help K` for why this keymap.
-          map('K', vim.lsp.buf.hover, 'Hover Documentation')
-
           -- WARN: This is not Goto Definition, this is Goto Declaration.
           --  For example, in C this would take you to the header.
           map('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')


### PR DESCRIPTION
This is now built into Neovim: https://neovim.io/doc/user/various.html#K-lsp-default
