### PR TITLE
Update lazydev configuration to fix "Undefined field `fs_stat`" LSP error

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -413,7 +413,17 @@ require('lazy').setup({
 
       -- `lazydev` configures Lua LSP for your Neovim config, runtime and plugins
       -- used for completion, annotations and signatures of Neovim apis
-      { 'folke/lazydev.nvim', ft = 'lua', opts = {} },
+      {
+        'folke/lazydev.nvim',
+        ft = 'lua',
+        opts = {
+          library = {
+            -- Load luvit types when the `vim.uv` word is found
+            { path = 'luvit-meta/library', words = { 'vim%.uv' } },
+          },
+        },
+      },
+      { 'Bilal2453/luvit-meta', lazy = true },
     },
     config = function()
       -- Brief aside: **What is LSP?**


### PR DESCRIPTION
https://github.com/nvim-lua/kickstart.nvim/pull/936 was just merged, and it had cherry-picked the changes from https://github.com/nvim-lua/kickstart.nvim/pull/961. Thus, it included the issue mentioned in https://github.com/nvim-lua/kickstart.nvim/pull/961#discussion_r1646808700: it introduced an LSP error in `init.lua`:

![image](https://github.com/user-attachments/assets/92456e86-1c56-4820-b1d1-52a00599a905)

which IMO degrades the desired "first timer" experience of kickstart.nvim.

This PR follows the configuration suggested in https://github.com/folke/lazydev.nvim/tree/6184ebbbc8045d70077659b7d30c705a588dc62f#-installation which resolves the LSP error.