### PR TITLE
Update comment about the toggle inlay hints keymap

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -533,7 +533,7 @@ require('lazy').setup({
             })
           end
 
-          -- The following autocommand is used to enable inlay hints in your
+          -- The following code creates a keymap to toggle inlay hints in your
           -- code, if the language server you are using supports them
           --
           -- This may be unwanted, since they displace some of your code


### PR DESCRIPTION
Fixes https://github.com/nvim-lua/kickstart.nvim/issues/968

> init.lua line 539:
> 
> ```
>          -- The following autocommand is used to enable inlay hints in your
>          -- code, if the language server you are using supports them
> ```
> 
> The code following the comment creates a keymap to toggle inlay hints, not an autocommand.