### PR TITLE
Add explicit dependency of nvim-lspconfig on cmp-nvim-lsp

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -424,6 +424,9 @@ require('lazy').setup({
         },
       },
       { 'Bilal2453/luvit-meta', lazy = true },
+
+      -- Allows extra capabilities provided by nvim-cmp
+      'hrsh7th/cmp-nvim-lsp',
     },
     config = function()
       -- Brief aside: **What is LSP?**


### PR DESCRIPTION
The plugin spec for `neovim/nvim-lspconfig` does a `require('cmp_nvim_lsp')` in the `LspAttach` event handler but does not explicitly add a dependency on `hrsh7th/cmp-nvim-lsp`.

This is fine in the default `kickstart.nvim` layout but may not work if someone decides to break the specs into separate folders or decides to remove/disable `nvim-cmp`.

This PR simply adds the explicit dependency where used.