### PR TITLE
performance: defer clipboard because xsel and pbcopy can be slow

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -111,9 +111,12 @@ vim.opt.mouse = 'a'
 vim.opt.showmode = false
 
 -- Sync clipboard between OS and Neovim.
+-- Schedule the setting after `UiEnter` because it can increase startup-time.
 --  Remove this option if you want your OS clipboard to remain independent.
 --  See `:help 'clipboard'`
-vim.opt.clipboard = 'unnamedplus'
+vim.schedule(function()
+  vim.opt.clipboard = 'unnamedplus'
+end)
 
 -- Enable break indent
 vim.opt.breakindent = true

--- a/init.lua
+++ b/init.lua
@@ -111,7 +111,7 @@ vim.opt.mouse = 'a'
 vim.opt.showmode = false
 
 -- Sync clipboard between OS and Neovim.
--- Schedule the setting after `UiEnter` because it can increase startup-time.
+--  Schedule the setting after `UiEnter` because it can increase startup-time.
 --  Remove this option if you want your OS clipboard to remain independent.
 --  See `:help 'clipboard'`
 vim.schedule(function()


### PR DESCRIPTION
See [this](https://github.com/LazyVim/LazyVim/discussions/4112) discussion in LazyVim

The approach discussed has been merged in [LazyVim](https://github.com/LazyVim/LazyVim/pull/4120) and [AstroNvim](https://github.com/AstroNvim/astrocore/pull/28)

TLDR: 
Startup time performance is affected quite significantly when the clipboard provider is `xsel`(linux) or `pbcopy`(macos). I expect an improvement in these cases, especially on older pc's.

This PR makes sure that `vim.opt.clipboard` is only applied after `UiEnter`. 