### PR TITLE
Modify Conform comments to prevent deprecation warning when used

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -653,9 +653,8 @@ require('lazy').setup({
         -- Conform can also run multiple formatters sequentially
         -- python = { "isort", "black" },
         --
-        -- You can use a sub-list to tell conform to run *until* a formatter
-        -- is found.
-        -- javascript = { { "prettierd", "prettier" } },
+        -- You can use 'stop_after_first' to run the first available formatter from the list
+        -- javascript = { "prettierd", "prettier", stop_after_first = true },
       },
     },
   },


### PR DESCRIPTION
At some point `Conform.nvim` switched from the sub-list syntax to including a `stop_after_first` argument. This PR updates the comment to use the new syntax so users don't get a deprecation warning after use.