### PR TITLE
Remove treesitter prefer_git option (unsafe!)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -856,8 +856,6 @@ require('lazy').setup({
     config = function(_, opts)
       -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 
-      -- Prefer git instead of curl in order to improve connectivity in some environments
-      require('nvim-treesitter.install').prefer_git = true
       ---@diagnostic disable-next-line: missing-fields
       require('nvim-treesitter.configs').setup(opts)
 


### PR DESCRIPTION
- It's not safe and can corrupt other git repos (when GIT_DIR and GIT_INDEX_FILE environment variables are set)
- nvim-treesiter maintainers consider `prefer_git` as deprecated and no longer needed.

See nvim-treesitter PR for details: https://github.com/nvim-treesitter/nvim-treesitter/pull/6959
