### PR TITLE
Add note in README about lazy-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ fork to your machine using one of the commands below, depending on your OS.
 > Your fork's url will be something like this:
 > `https://github.com/<your_github_username>/kickstart.nvim.git`
 
+You likely want to remove `lazy-lock.json` from your fork's `.gitignore` file
+too - it's ignored in the kickstart repo to make maintenance easier, but it's
+[recommmended to track it in version control](https://lazy.folke.io/usage/lockfile).
+
 #### Clone kickstart.nvim
 > **NOTE**
 > If following the recommended step above (i.e., forking the repo), replace


### PR DESCRIPTION
As discussed in #1078, we want to git-ignore lazy-lock.json in the kickstart repo, but prompt users to unignore it in their own forks.