### PR TITLE
Add ripgrep as a telescope dependency

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -340,6 +340,7 @@ require('lazy').setup({
     branch = '0.1.x',
     dependencies = {
       'nvim-lua/plenary.nvim',
+      'BurntSushi/ripgrep',
       { -- If encountering errors, see telescope-fzf-native README for installation instructions
         'nvim-telescope/telescope-fzf-native.nvim',
 


### PR DESCRIPTION
I was testing my config, and found out that the telescope `live_grep` builtin search did not work properly.

After a bit of digging I found out that ripgrep is a dependency of telescope, therefore I added it to the config.

Link to telescope documentation: [https://github.com/nvim-telescope/telescope.nvim?tab=readme-ov-file#suggested-dependencies](https://github.com/nvim-telescope/telescope.nvim?tab=readme-ov-file#suggested-dependencies)