### PR TITLE
Revert removal of diagnostic.open_float

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -544,6 +544,10 @@ require('lazy').setup({
           -- or a suggestion from your LSP for this to activate.
           map('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction')
 
+          -- Open Code diagnostic in float window. your cursor needs to be on top of an error
+          -- Alternatively a hotkey were added in nvim 0.10 <C-W>d to do this functionaly by default
+          map('<leader>cd', vim.diagnostic.open_float, '[C]ode [D]iagnostic')
+
           -- WARN: This is not Goto Definition, this is Goto Declaration.
           --  For example, in C this would take you to the header.
           map('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')


### PR DESCRIPTION
This kickstart has been a great way to get into a minimalistic pre-configuration. However, after going through it my self, I have noticed that the diagnostic key does not exist in the LSP.

I didn't know why at the time, and it is a very useful function that I use it all the time in my previous setup. It was hard to believe that it was NEVER included, so I had to dig through history to find out why and where was it removed. Then I found out that it was removed due nvim 0.10 release and the introduction of <C-W>d default hotkey. I didn't even know this hotkey existed if I weren't going through this.

This was a brief explanation of my personal experience, and personally I feel that it is removed way too soon. Not many people going to be familiar with the <C-W>d hotkey right away, especially that 0.10 is a newish release and many people haven't caught up yet. I think adding this Code Diagnostic command in the LSP can be helpful, with the comment introduction of the <C-W>d hotkey as well for those who prefer to opt out of it.

In the future, when many people are familiar with the new default hotkey, it can be removed.