### PR TITLE
Enable silent option for default neo-tree plugin keybinding

### DIFF
--- a/lua/kickstart/plugins/neo-tree.lua
+++ b/lua/kickstart/plugins/neo-tree.lua
@@ -11,7 +11,7 @@ return {
   },
   cmd = 'Neotree',
   keys = {
-    { '\\', ':Neotree reveal<CR>', desc = 'NeoTree reveal' },
+    { '\\', ':Neotree reveal<CR>', desc = 'NeoTree reveal', silent = true },
   },
   opts = {
     filesystem = {


### PR DESCRIPTION
When the keybinding is spammed, the command ran for revealing neo-tree is displayed in cmdline and this is especially annoying while used with noice.nvim or similar configuration. Silent option is currently missing to fix this minor issue.
