### PR TITLE
Add nvim-window-picker for neo-tree plugin

### DIFF
--- a/lua/kickstart/plugins/neo-tree.lua
+++ b/lua/kickstart/plugins/neo-tree.lua
@@ -8,6 +8,7 @@ return {
     'nvim-lua/plenary.nvim',
     'nvim-tree/nvim-web-devicons', -- not strictly required, but recommended
     'MunifTanjim/nui.nvim',
+    's1n7ax/nvim-window-picker',
   },
   cmd = 'Neotree',
   keys = {


### PR DESCRIPTION
neo-tree need  s1n7ax/nvim-window-picker plugin to open file in a picked window
