### PR TITLE
Add undotree support to Kickstart.nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -910,8 +910,9 @@ require('lazy').setup({
 
   { -- Review undo history with a tree view
     'mbbill/undotree',
-    event = 'VeryLazy', -- Set the loading event to 'VeryLazy'
-    vim.keymap.set('n', '<leader>vu', ':UndotreeToggle<CR>', { desc = 'Toggle Undotree' }),
+    keys = {
+      {'<leader>vu', ':UndotreeToggle<CR>', desc = 'Toggle Undotree' }
+    }
   },
 
   -- The following two comments only work if you have downloaded the kickstart repo, not just copy pasted the

--- a/init.lua
+++ b/init.lua
@@ -908,6 +908,12 @@ require('lazy').setup({
     --    - Treesitter + textobjects: https://github.com/nvim-treesitter/nvim-treesitter-textobjects
   },
 
+  { -- Review undo history with a tree view
+    'mbbill/undotree',
+    event = 'VeryLazy', -- Set the loading event to 'VeryLazy'
+    vim.keymap.set('n', '<leader>vu', ':UndotreeToggle<CR>', { desc = 'Toggle Undotree' }),
+  },
+
   -- The following two comments only work if you have downloaded the kickstart repo, not just copy pasted the
   -- init.lua. If you want these files, they are in the repository, so you can just download them and
   -- place them in the correct locations.


### PR DESCRIPTION
This PR integrates Undotree support into the Kickstart.nvim configuration. The Undotree plugin provides a visual representation of the undo history, allowing users to easily navigate and manage their undo actions.  

Key Changes:
- Added configuration for the Undotree plugin to the Kickstart.nvim setup.
- Updated the plugin manager to include Undotree.
- Included basic key mappings for opening and interacting with the Undotree.  

Benefits:
- Enhances the user experience by providing a graphical interface for undo history.
- Improves workflow efficiency by making it easier to visualize and revert changes.