### PR TITLE
feat: update references of tsserver to ts_ls

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -614,8 +614,8 @@ require('lazy').setup({
         -- Some languages (like typescript) have entire language plugins that can be useful:
         --    https://github.com/pmizio/typescript-tools.nvim
         --
-        -- But for many setups, the LSP (`tsserver`) will work just fine
-        -- tsserver = {},
+        -- But for many setups, the LSP (`ts_ls`) will work just fine
+        -- ts_ls = {},
         --
 
         lua_ls = {
@@ -656,7 +656,7 @@ require('lazy').setup({
             local server = servers[server_name] or {}
             -- This handles overriding only values explicitly passed
             -- by the server configuration above. Useful when disabling
-            -- certain features of an LSP (for example, turning off formatting for tsserver)
+            -- certain features of an LSP (for example, turning off formatting for ts_ls)
             server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
             require('lspconfig')[server_name].setup(server)
           end,


### PR DESCRIPTION
nvim-lspconfig renamed `tsserver` to `ts_ls` (see this [PR](https://github.com/neovim/nvim-lspconfig/pull/3232))

This causes a warning everytime you start nvim because Mason hasn't changed `tsserver` name to `ts_ls`.

This PR fixes it by adding an if statement to check if the server name is `tsserver` and updates it to `ts_ls` in `mason-lspconfig.setup` [(Credits)](https://github.com/neovim/nvim-lspconfig/pull/3232#issuecomment-2331025714)

Also it replaces every reference of `tsserver` to `ts_ls`