### PR TITLE
Fix file navigation delay in Ruby caused by ts indent

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -892,7 +892,7 @@ require('lazy').setup({
       -- Autoinstall languages that are not installed
       auto_install = true,
       highlight = { enable = true },
-      indent = { enable = true },
+      indent = { enable = true, disable = { 'ruby' } },
     },
     -- There are additional nvim-treesitter modules that you can use to interact
     -- with nvim-treesitter. You should go explore a few and see what interests you:

--- a/init.lua
+++ b/init.lua
@@ -891,14 +891,8 @@ require('lazy').setup({
       ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
       -- Autoinstall languages that are not installed
       auto_install = true,
-      highlight = {
-        enable = true,
-        -- Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.
-        --  If you are experiencing weird indenting issues, add the language to
-        --  the list of additional_vim_regex_highlighting and disabled languages for indent.
-        additional_vim_regex_highlighting = { 'ruby' },
-      },
-      indent = { enable = true, disable = { 'ruby' } },
+      highlight = { enable = true },
+      indent = { enable = true },
     },
     -- There are additional nvim-treesitter modules that you can use to interact
     -- with nvim-treesitter. You should go explore a few and see what interests you:


### PR DESCRIPTION
Related to / Fixes issue https://github.com/nvim-lua/kickstart.nvim/issues/1141.

Caused by `additional_vim_regex_highlighting = { 'ruby' }` line for Ruby in kickstart ts config that was introduced in [this commit ](https://github.com/nvim-lua/kickstart.nvim/commit/7892c0c354639985b1cf36f11d175201590e267b).

The problem this solved at the time seems redundant now (most likely fixed upstream in `treesitter`), and now introduces a small delay when navigating in files instead.

~~I reverted the commit - restoring default ts indenting for it, in turn making config simpler.~~
Edit: Only ts regex highlighting was removed to avoid regressions - thanks @ChillerDragon.