### PR TITLE
Add nvim-ufo as an option

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -922,6 +922,7 @@ require('lazy').setup({
   -- require 'kickstart.plugins.lint',
   -- require 'kickstart.plugins.autopairs',
   -- require 'kickstart.plugins.neo-tree',
+  -- require 'kickstart.plugins.nvim-ufo',
   -- require 'kickstart.plugins.gitsigns', -- adds gitsigns recommend keymaps
 
   -- NOTE: The import below can automatically add your own plugins, configuration, etc from `lua/custom/plugins/*.lua`

--- a/lua/kickstart/plugins/nvim-ufo.lua
+++ b/lua/kickstart/plugins/nvim-ufo.lua
@@ -1,0 +1,19 @@
+-- Makes folding look modern and keep high performance
+return {
+  'kevinhwang91/nvim-ufo',
+  dependencies = { 'kevinhwang91/promise-async' },
+  config = function()
+    vim.opt.foldlevel = 99 -- Using ufo provider need a large value, feel free to decrease the value
+    vim.opt.foldlevelstart = 99
+
+    -- treesitter as a main provider instead
+    -- (Note: the `nvim-treesitter` plugin is *not* needed.)
+    -- ufo uses the same query files for folding (queries/<lang>/folds.scm)
+    -- performance and stability are better than `foldmethod=nvim_treesitter#foldexpr()`
+    require('ufo').setup {
+      provider_selector = function(bufnr, filetype, buftype)
+        return { 'treesitter', 'indent' }
+      end,
+    }
+  end,
+}


### PR DESCRIPTION
It is really annoying for me to set the foldings every time I open a file, so I have looked for a plugin that set them automatically like VSCode; [nvim-ufo](https://github.com/kevinhwang91/nvim-ufo) and added it.

I understand that adding this is controversial, especially from a "kickstart" perspective, but I think it is worth adding them if **only as an option**.

I often use this feature when coding to hide parts of the code that I don't need to see, and I personally believe it would be inconvenient for VSCode users to be without them when they first touch Neovim. Howerver, I think the opinion that there is no need to bother putting it in lua/kickstart/plugins if there seems to be no demand for it from many users should also be respected.

I would appreciate your thoughts on this.