### PR TITLE
fix(lsp): remove BufEnter event on linting

### DIFF
--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -44,7 +44,7 @@ return {
       -- Create autocommand which carries out the actual linting
       -- on the specified events.
       local lint_augroup = vim.api.nvim_create_augroup('lint', { clear = true })
-      vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
+      vim.api.nvim_create_autocmd({ 'BufWritePost', 'InsertLeave' }, {
         group = lint_augroup,
         callback = function()
           lint.try_lint()


### PR DESCRIPTION
When in use, linting will also be triggered when viewing lsp signature help (or lsp hover)

If you enter a hover- or signature help window, markdownlint triggers warninging within the LSP window. This is very annoying and shouldn't be triggered.

Here is a screenshot what happens when entering a LSP window.

![image](https://github.com/user-attachments/assets/3b28cae4-bd46-47b4-b0be-db4f7f8cd9ce)

