### PR TITLE
Disable linting autocmd for readonly buffers

### DIFF
--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -47,7 +47,9 @@ return {
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
         group = lint_augroup,
         callback = function()
-          lint.try_lint()
+          if vim.opt_local.modifiable:get() then
+            lint.try_lint()
+          end
         end,
       })
     end,

--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -47,6 +47,9 @@ return {
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
         group = lint_augroup,
         callback = function()
+          -- Only run the linter in buffers that you can modify in order to
+          -- avoid superfluous noise, notably within the handy LSP pop-ups that
+          -- describe the hovered symbol using Markdown.
           if vim.opt_local.modifiable:get() then
             lint.try_lint()
           end


### PR DESCRIPTION
Disable linting autocmd for readonly buffers.

This should avoid linting in buffers outside of the user's control, having in mind especially the handy LSP pop-ups that describe your hovered symbol using markdown.

I added @rgruyters as a co-author, because he's the one who engaged the discussion on this topic in [his pull request](https://github.com/nvim-lua/kickstart.nvim/pull/1200).