### PR TITLE
Simplify extended plugin comment.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -908,14 +908,11 @@ require('lazy').setup({
     --    - Treesitter + textobjects: https://github.com/nvim-treesitter/nvim-treesitter-textobjects
   },
 
-  -- The following two comments only work if you have downloaded the kickstart repo, not just copy pasted the
-  -- init.lua. If you want these files, they are in the repository, so you can just download them and
-  -- place them in the correct locations.
-
   -- NOTE: Next step on your Neovim journey: Add/Configure additional plugins for Kickstart
   --
   --  Here are some example plugins that I've included in the Kickstart repository.
   --  Uncomment any of the lines below to enable them (you will need to restart nvim).
+  --  These are separate config files found in the lua/kickstart/plugins directory.
   --
   -- require 'kickstart.plugins.debug',
   -- require 'kickstart.plugins.indent_line',


### PR DESCRIPTION
Simplify and clarify the extended plugin configuration comment.

This change could also simply remove "two", but I found most of the original comment to be unnecessary.