### PR TITLE
Remove "two" because there are more than two.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -908,7 +908,7 @@ require('lazy').setup({
     --    - Treesitter + textobjects: https://github.com/nvim-treesitter/nvim-treesitter-textobjects
   },
 
-  -- The following two comments only work if you have downloaded the kickstart repo, not just copy pasted the
+  -- The following comments only work if you have downloaded the kickstart repo, not just copy pasted the
   -- init.lua. If you want these files, they are in the repository, so you can just download them and
   -- place them in the correct locations.
 


### PR DESCRIPTION
I had nearly asked in #1210 if people copy/pasting init.lua was a real problem, sounds like it is so the comment makes sense.

There are still more than two commented out plugins, so here is the basic "fix".