### PR TITLE
fix: which-key comment typo

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -279,7 +279,7 @@ require('lazy').setup({
         -- set icon mappings to true if you have a Nerd Font
         mappings = vim.g.have_nerd_font,
         -- If you are using a Nerd Font: set icons.keys to an empty table which will use the
-        -- default whick-key.nvim defined Nerd Font icons, otherwise define a string table
+        -- default which-key.nvim defined Nerd Font icons, otherwise define a string table
         keys = vim.g.have_nerd_font and {} or {
           Up = '<Up> ',
           Down = '<Down> ',


### PR DESCRIPTION
Found a typo in `init.lua` when I was reading the notes for which-key.nvim.

Replaced `whick-key.nvim` with `which-key.nvim`.
