### PR TITLE
Prepare for upcoming deprecation of configuring diagnostic-signs using sign_define()

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -590,11 +590,12 @@ require('lazy').setup({
 
       -- Change diagnostic symbols in the sign column (gutter)
       -- if vim.g.have_nerd_font then
-      --   local signs = { Error = '', Warn = '', Hint = '', Info = '' }
+      --   local signs = { ERROR = '', WARN = '', INFO = '', HINT = '' }
+      --   local diagnostic_signs = {}
       --   for type, icon in pairs(signs) do
-      --     local hl = 'DiagnosticSign' .. type
-      --     vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
+      --     diagnostic_signs[vim.diagnostic.severity[type]] = icon
       --   end
+      --   vim.diagnostic.config { signs = { text = diagnostic_signs } }
       -- end
 
       -- LSP servers and clients are able to communicate to each other what features they support.


### PR DESCRIPTION
Since Neovim 0.10, it seems that configuring diagnostic-signs using sign_define() has been [deprecated](https://neovim.io/doc/user/deprecated.html#_checkhealth).
There is another way to set them as follows:
```
if vim.g.have_nerd_font then
  vim.diagnostic.config {
    signs = {
      text = {
        [vim.diagnostic.severity.ERROR] = '',
        [vim.diagnostic.severity.WARN] = '',
        [vim.diagnostic.severity.INFO] = '',
        [vim.diagnostic.severity.HINT] = '',
      },
    },
  }
end
```
In the committed one, I simply focused on fewer lines and readability(after all, this section is commented out).