### PR TITLE
Use consistent syntax style for { ... } "pseudocode"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -629,8 +629,8 @@ require('lazy').setup({
         --
 
         lua_ls = {
-          -- cmd = {...},
-          -- filetypes = { ...},
+          -- cmd = { ... },
+          -- filetypes = { ... },
           -- capabilities = {},
           settings = {
             Lua = {


### PR DESCRIPTION
```lua
require('gitsigns').setup({ ... })
```

This was the first occurrence

It may be nice to have the same style everywhere

Cosmetic change (just to make docs/comments even more perfect)