### PR TITLE
fix(gitsigns): make visual mode descriptions consistent with normal mode

### DIFF
--- a/lua/kickstart/plugins/gitsigns.lua
+++ b/lua/kickstart/plugins/gitsigns.lua
@@ -36,10 +36,10 @@ return {
         -- visual mode
         map('v', '<leader>hs', function()
           gitsigns.stage_hunk { vim.fn.line '.', vim.fn.line 'v' }
-        end, { desc = 'stage git hunk' })
+        end, { desc = 'git [s]tage hunk' })
         map('v', '<leader>hr', function()
           gitsigns.reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
-        end, { desc = 'reset git hunk' })
+        end, { desc = 'git [r]eset hunk' })
         -- normal mode
         map('n', '<leader>hs', gitsigns.stage_hunk, { desc = 'git [s]tage hunk' })
         map('n', '<leader>hr', gitsigns.reset_hunk, { desc = 'git [r]eset hunk' })


### PR DESCRIPTION
Update visual mode keymaps for "stage hunk" and "reset hunk" to match normal mode descriptions.