### PR TITLE
Fix which-key delay settings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -135,7 +135,6 @@ vim.opt.signcolumn = 'yes'
 vim.opt.updatetime = 250
 
 -- Decrease mapped sequence wait time
--- Displays which-key popup sooner
 vim.opt.timeoutlen = 300
 
 -- Configure how new splits should be opened
@@ -274,6 +273,9 @@ require('lazy').setup({
     'folke/which-key.nvim',
     event = 'VimEnter', -- Sets the loading event to 'VimEnter'
     opts = {
+      -- delay between pressing a key and opening which-key (milliseconds)
+      -- this setting is independent of vim.opt.timeoutlen
+      delay = 0,
       icons = {
         -- set icon mappings to true if you have a Nerd Font
         mappings = vim.g.have_nerd_font,


### PR DESCRIPTION
I was trying to make which-key pop up instantly.  I tried changing `vim.opt.timeoutlen` to 0, then to 1000, but it made no difference.  While searching through the `which-key` repository, I discovered they changed how the plugin's delay is configured. They used to rely on `vim.opt.timeoutlen`, [but they changed that a few months ago](https://github.com/folke/which-key.nvim/blob/8ab96b38a2530eacba5be717f52e04601eb59326/NEWS.md?plain=1#L10).  Now they use their own `opt.delay` instead.

The previous 300 ms delay led me assume there was some horribly inefficient code somewhere in neovim, lua, or which-key.  I changed the delay to 0 ms and that makes `which-key` feel really snappy and responsive!  I think other newcomers to neovim would appreciate that feel.