### PR TITLE
Sync vim diagnostic local list with LSP.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -165,7 +165,9 @@ vim.opt.scrolloff = 10
 vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
 
 -- Diagnostic keymaps
-vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })
+vim.keymap.set('n', '<leader>q', function()
+  vim.diagnostic.setloclist { open = true }
+end, { desc = 'Open and sync diagnostic [Q]uickfix list' })
 
 -- Exit terminal mode in the builtin terminal with a shortcut that is a bit easier
 -- for people to discover. Otherwise, you normally need to press <C-\><C-n>, which


### PR DESCRIPTION
This update ensures synchronization between the local Vim diagnostic list and the LSP.

The issue arose with the _clangd_ LSP, where the local diagnostic list retained syntax errors reported by _clangd_ even after they were resolved and _clangd_ no longer reported them.

While it's unclear if this problem exists for other programming languages, this PR effectively addresses the issue for _clangd_ when working with C/C++.


