### PR TITLE
fix: prevent mason setup from being run twice

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -457,7 +457,16 @@ require('lazy').setup({
     'neovim/nvim-lspconfig',
     dependencies = {
       -- Automatically install LSPs and related tools to stdpath for Neovim
-      { 'williamboman/mason.nvim', config = true }, -- NOTE: Must be loaded before dependants
+      {
+        'williamboman/mason.nvim',
+        -- Mason must be loaded before its dependents so we'll define `opts`
+        -- here: this will make `lazy` automatically run
+        -- `require('mason').setup(opts)` when `nvim-lspconfig` loads.
+        opts = {
+          -- Add overrides for mason's default settings here if needed! e.g.:
+          -- log_level = vim.log.levels.DEBUG,
+        },
+      },
       'williamboman/mason-lspconfig.nvim',
       'WhoIsSethDaniel/mason-tool-installer.nvim',
 
@@ -646,13 +655,16 @@ require('lazy').setup({
       }
 
       -- Ensure the servers and tools above are installed
-      --  To check the current status of installed tools and/or manually install
-      --  other tools, you can run
+      --
+      -- To check the current status of installed tools and/or manually install
+      -- other tools, you can run
       --    :Mason
       --
-      --  You can press `g?` for help in this menu.
-      require('mason').setup()
-
+      -- You can press `g?` for help in this menu.
+      --
+      -- `mason` had to be setup earlier: to configure its options see the
+      -- `dependencies` table for `nvim-lspconfig` above.
+      --
       -- You can add other tools here that you want Mason to install
       -- for you, so that they are available from within Neovim.
       local ensure_installed = vim.tbl_keys(servers or {})

--- a/init.lua
+++ b/init.lua
@@ -457,16 +457,9 @@ require('lazy').setup({
     'neovim/nvim-lspconfig',
     dependencies = {
       -- Automatically install LSPs and related tools to stdpath for Neovim
-      {
-        'williamboman/mason.nvim',
-        -- Mason must be loaded before its dependents so we'll define `opts`
-        -- here: this will make `lazy` automatically run
-        -- `require('mason').setup(opts)` when `nvim-lspconfig` loads.
-        opts = {
-          -- Add overrides for mason's default settings here if needed! e.g.:
-          -- log_level = vim.log.levels.DEBUG,
-        },
-      },
+      -- Mason must be loaded before its dependents so we need to set it up here.
+      -- NOTE: `opts = {}` is the same as calling `require('mason').setup({})`
+      { 'williamboman/mason.nvim', opts = {} },
       'williamboman/mason-lspconfig.nvim',
       'WhoIsSethDaniel/mason-tool-installer.nvim',
 


### PR DESCRIPTION
Addresses https://github.com/nvim-lua/kickstart.nvim/issues/1297

Currently, we're calling `require('mason').setup(...)` twice:
* once when setting it as a dependency of `nvim-lspconfig` (since we set `config = true`)
* once in the `config` function we define for `nvim-lspconfig`

Calling setup twice can cause issues with, e.g., setting the `PATH` option: you might append Mason's bin dir in one setup call and prepend it in the other.

We've kept the setup of `mason` in the `nvim-lspconfig` dependencies table since leaving it to the `config` function caused some plugin-loading-order related issues in the past. See:
* https://github.com/nvim-lua/kickstart.nvim/pull/210
* https://github.com/nvim-lua/kickstart.nvim/issues/554
* https://github.com/nvim-lua/kickstart.nvim/pull/555
* https://github.com/nvim-lua/kickstart.nvim/pull/865

