### PR TITLE
Remove the additional_vim_regex_highlighting clause which is discouraged.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -912,9 +912,10 @@ require('lazy').setup({
         -- Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.
         --  If you are experiencing weird indenting issues, add the language to
         --  the list of additional_vim_regex_highlighting and disabled languages for indent.
-        additional_vim_regex_highlighting = { 'ruby' },
+        -- additional_vim_regex_highlighting = { 'ruby' },
       },
-      indent = { enable = true, disable = { 'ruby' } },
+      -- indent = { enable = true, disable = { 'ruby' } },
+      indent = { enable = true },
     },
     -- There are additional nvim-treesitter modules that you can use to interact
     -- with nvim-treesitter. You should go explore a few and see what interests you:


### PR DESCRIPTION
As per #1141 

Remove the additional_vim_regex_highlighting clause which is discouraged.

https://www.reddit.com/r/neovim/comments/yxjrkr/treesitter_syntax_highlighting_too_slow_on_large/

[I am creating this PR against the main nvim-lua/kickstart.nvim because I maintain my own incompatible fork.]