### PR TITLE
lazydev.nvim: Use luals 3rd library for luv

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -447,11 +447,10 @@ require('lazy').setup({
     opts = {
       library = {
         -- Load luvit types when the `vim.uv` word is found
-        { path = 'luvit-meta/library', words = { 'vim%.uv' } },
+        { path = '${3rd}/luv/library', words = { 'vim%.uv' } },
       },
     },
   },
-  { 'Bilal2453/luvit-meta', lazy = true },
   {
     -- Main LSP Configuration
     'neovim/nvim-lspconfig',


### PR DESCRIPTION
lazydev.nvim: Follows installation instructions as updated in https://github.com/folke/lazydev.nvim/commit/f125453e2b2c615eeeba96f321590b969869e27c which:

- Changes path for loading luvit types
- Removes the dependency on https://github.com/Bilal2453/luvit-meta

