### PR TITLE
docs: clarify using opts = {} vs config = function() ... require('plu…

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -250,7 +250,7 @@ require('lazy').setup({
   --
   -- Here is a more advanced example where we pass configuration
   -- options to `gitsigns.nvim`.
-  --  
+  --
   -- See `:help gitsigns` to understand what the configuration keys do
   { -- Adds git related signs to the gutter, as well as utilities for managing changes
     'lewis6991/gitsigns.nvim',

--- a/init.lua
+++ b/init.lua
@@ -236,6 +236,7 @@ require('lazy').setup({
   --
   -- Use `opts = {}` to automatically pass options to a plugin's `setup()` function, forcing the plugin to be loaded.
   --
+
   -- Alternatively, use `config = function() ... end` for full control over the configuration.
   -- If you prefer to call `setup` explicitly, use:
   --    {

--- a/init.lua
+++ b/init.lua
@@ -234,13 +234,22 @@ require('lazy').setup({
   -- with the first argument being the link and the following
   -- keys can be used to configure plugin behavior/loading/etc.
   --
-  -- Use `opts = {}` to force a plugin to be loaded.
+  -- Use `opts = {}` to automatically pass options to a plugin's `setup()` function, forcing the plugin to be loaded.
   --
-
+  -- Alternatively, use `config = function() ... end` for full control over the configuration.
+  -- If you prefer to call `setup` explicitly, use:
+  --    {
+  --        'lewis6991/gitsigns.nvim',
+  --        config = function()
+  --            require('gitsigns').setup({
+  --                -- Your gitsigns configuration here
+  --            })
+  --        end,
+  --    }
+  --
   -- Here is a more advanced example where we pass configuration
-  -- options to `gitsigns.nvim`. This is equivalent to the following Lua:
-  --    require('gitsigns').setup({ ... })
-  --
+  -- options to `gitsigns.nvim`.
+  --  
   -- See `:help gitsigns` to understand what the configuration keys do
   { -- Adds git related signs to the gutter, as well as utilities for managing changes
     'lewis6991/gitsigns.nvim',


### PR DESCRIPTION
The current documentation mentioning that using "require" is equivalent to using "opts" without detailing the use in the "config = function()" block seems inaccurate.

Lower in the configuration the "config = function()" block is used without clarifying why it is needed and what it does.

This clarification may help new users understand the difference between the two, or how and where to place the "require" statement in order for it to be equivalent to using "opts".
