### PR TITLE
Propsed fix for init.lua warnings without disabling diagnostics

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -675,6 +675,8 @@ require('lazy').setup({
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
       require('mason-lspconfig').setup {
+        ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
+        automatic_installation = false,
         handlers = {
           function(server_name)
             local server = servers[server_name] or {}


### PR DESCRIPTION
Proposed fix as per https://github.com/nvim-lua/kickstart.nvim/issues/1305#issuecomment-2657770325

FOLKS SHOULD TEST THIS THOROUGHLY. I'm not having any issues but I'd love more feedback please.

***************************************************************************
**NOTE**
Please verify that the `base repository` above has the intended destination!
Github by default opens Pull Requests against the parent of a forked repository.
If this is your personal fork and you didn't intend to open a PR for contribution
to the original project then adjust the `base repository` accordingly.
**************************************************************************

