### PR TITLE
Possible unintended behavior in Conform's opts format_on_save 

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -744,16 +744,14 @@ require('lazy').setup({
         -- have a well standardized coding style. You can add additional
         -- languages here or re-enable it for the disabled ones.
         local disable_filetypes = { c = true, cpp = true }
-        local lsp_format_opt
         if disable_filetypes[vim.bo[bufnr].filetype] then
-          lsp_format_opt = 'never'
+          return nil
         else
-          lsp_format_opt = 'fallback'
+          return {
+            timeout_ms = 500,
+            lsp_format = 'fallback',
+          }
         end
-        return {
-          timeout_ms = 500,
-          lsp_format = lsp_format_opt,
-        }
       end,
       formatters_by_ft = {
         lua = { 'stylua' },


### PR DESCRIPTION
This pull request changes Conform's format_on_save lambda so that buffers that match disable_filetypes return nil instead of a table with the lsp_format  entry equaling "never". This allows you to enable a formatter for langages in the disable_filetypes table to have a formatter that can be run manually with Leader-f but doesn't enable format_on_save for them. Before this change, if you add a formatter for a language such as c, like clang-format, it enables format_on_save since the formatter is set explicitly. I think this probably isn't the intended behavior but in case it is, feel free to reject this PR.



