### PR TITLE
fix(Telescope): remove Telescope `0.1` branch lock

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -357,7 +357,6 @@ require('lazy').setup({
   { -- Fuzzy Finder (files, lsp, etc)
     'nvim-telescope/telescope.nvim',
     event = 'VimEnter',
-    branch = '0.1.x',
     dependencies = {
       'nvim-lua/plenary.nvim',
       { -- If encountering errors, see telescope-fzf-native README for installation instructions


### PR DESCRIPTION
Telescope hasn't had a release in over a year. Sticking to old version will omit lots of fixes.
For instance dynamic workspace symbols won't work and will throw an error in latest nvim version.