### PR TITLE
fix: renamed vim.highlight.on_yank to vim.hl.on_yank

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -205,12 +205,12 @@ vim.keymap.set('n', '<C-k>', '<C-w><C-k>', { desc = 'Move focus to the upper win
 
 -- Highlight when yanking (copying) text
 --  Try it with `yap` in normal mode
---  See `:help vim.highlight.on_yank()`
+--  See `:help vim.hl.on_yank()`
 vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function()
-    vim.highlight.on_yank()
+    vim.hl.on_yank()
   end,
 })
 


### PR DESCRIPTION
Firstly, thank you for an awesome project. I'm considering switching from vim to nvim, and this is a great help getting started with my configuration.

I didn't find a contributing guidelines, hope this PR is okay.  
I've found a small use of a deprecated nvim function, so thought that it might help future users if we use the current (nvim 0.11+) version of the function. More info below.

The functions of vim.highlight were renamed to vim.hl on commit 18b43c331d8a0ed87d7cbefe2a18543b8e4ad360 of neovim, which was applied with the release of nvim version 0.11.

Now, the use of vim.highlight is deprecated, and instead, one should use vim.hl functions.
In practice, vim.highlight is still working, however, asking for help for vim.highlight.on_yank fails (E149), while asking for help for vim.hl.on_yank works as expected. So, by updating the used function, a new user will have easier time looking getting the relevant help.
