### PR TITLE
Improve fidget.nvim to handle all notifications

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -478,8 +478,15 @@ require('lazy').setup({
       'williamboman/mason-lspconfig.nvim',
       'WhoIsSethDaniel/mason-tool-installer.nvim',
 
-      -- Useful status updates for LSP.
-      { 'j-hui/fidget.nvim', opts = {} },
+      -- Provides polished UI notifications for LSP and other plugins.
+      {
+        'j-hui/fidget.nvim',
+        opts = {
+          notification = {
+            override_vim_notify = true, -- Override vim.notify() to use Fidget's notifications
+          },
+        },
+      },
 
       -- Allows extra capabilities provided by blink.cmp
       'saghen/blink.cmp',


### PR DESCRIPTION
Since we are already using fidget.nvim to handle LSP updates, why not extend its functionality to override vim.notify() and allow it to show all notifications for more consistency and better UX.

