### PR TITLE
fix(neo-tree): allow neo-tree to hijack netrw on startup

### DIFF
--- a/lua/kickstart/plugins/neo-tree.lua
+++ b/lua/kickstart/plugins/neo-tree.lua
@@ -9,7 +9,7 @@ return {
     'nvim-tree/nvim-web-devicons', -- not strictly required, but recommended
     'MunifTanjim/nui.nvim',
   },
-  cmd = 'Neotree',
+  lazy = false,
   keys = {
     { '\\', ':Neotree reveal<CR>', desc = 'NeoTree reveal', silent = true },
   },


### PR DESCRIPTION
hi, Neo-tree maintainer here.

The Neo-tree spec here has an issue where it lazyloads neo-tree and thus stops neo-tree from being able to hijack netrw until the user opens Neo-tree. this seems like inconsistent behavior from a user perspective.

On recent versions of Neo-tree, manual user-side lazyloading for neo-tree is pretty much unnecessary (all the expensive setup work is delayed until Neo-tree is opened or the command is typed, so startup times should be very minimal when not hijacking on startup), so i'd like to remove the lazyloading here such that users get the intended experience.