### PR TITLE
fix: correct gitsigns mapping for <leader>tD

### DIFF
--- a/lua/kickstart/plugins/gitsigns.lua
+++ b/lua/kickstart/plugins/gitsigns.lua
@@ -54,7 +54,7 @@ return {
         end, { desc = 'git [D]iff against last commit' })
         -- Toggles
         map('n', '<leader>tb', gitsigns.toggle_current_line_blame, { desc = '[T]oggle git show [b]lame line' })
-        map('n', '<leader>tD', gitsigns.preview_hunk_inline, { desc = '[T]oggle git show [D]eleted' })
+        map('n', '<leader>td', gitsigns.toggle_deleted, { desc = '[T]oggle git show [d]eleted' })
       end,
     },
   },


### PR DESCRIPTION
The previous mapping <leader>tD was described as "[T]oggle git show [D]eleted" but was mapped to preview_hunk_inline, which didn't match the description. This commit updates the mapping to toggle_deleted, which fits the description.

***************************************************************************
**NOTE**
Please verify that the `base repository` above has the intended destination!
Github by default opens Pull Requests against the parent of a forked repository.
If this is your personal fork and you didn't intend to open a PR for contribution
to the original project then adjust the `base repository` accordingly.
**************************************************************************

