### PR TITLE
feat: switch vim-sleuth for guess-indent.nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -239,7 +239,7 @@ vim.opt.rtp:prepend(lazypath)
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
-  'tpope/vim-sleuth', -- Detect tabstop and shiftwidth automatically
+  'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
 
   -- NOTE: Plugins can also be added by using a table,
   -- with the first argument being the link and the following


### PR DESCRIPTION
guess-indent.nvim provides the same functionality as vim-sleuth, but is faster since it is written in Lua. Additionally for existing Kickstart users, switching from vim-sleuth to guess-indent will be seamless.

I found a benchmark result comparing vim-sleuth and guess-indent here: https://www.reddit.com/r/neovim/comments/t6o2z4/guessindent_automatic_indentation_style_detection/
