### PR TITLE
Change to Mason's new address

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -474,8 +474,8 @@ require('lazy').setup({
       -- Automatically install LSPs and related tools to stdpath for Neovim
       -- Mason must be loaded before its dependents so we need to set it up here.
       -- NOTE: `opts = {}` is the same as calling `require('mason').setup({})`
-      { 'williamboman/mason.nvim', opts = {} },
-      'williamboman/mason-lspconfig.nvim',
+      { 'mason-org/mason.nvim', opts = {} },
+      'mason-org/mason-lspconfig.nvim',
       'WhoIsSethDaniel/mason-tool-installer.nvim',
 
       -- Useful status updates for LSP.


### PR DESCRIPTION
Mason has changed their URL recently and so we also apply accordingly

https://github.com/mason-org/mason.nvim/releases

