### PR TITLE
fix #1519: disable completion in *only* shell command mode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -857,6 +857,12 @@ require('lazy').setup({
         default = { 'lsp', 'path', 'snippets', 'lazydev' },
         providers = {
           lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
+          cmdline = {
+            -- ignores cmdline completions when executing shell commands
+            enabled = function()
+              return vim.fn.getcmdtype() ~= ':' or not vim.fn.getcmdline():match "^[%%0-9,'<>%-]*!"
+            end,
+          },
         },
       },
 


### PR DESCRIPTION
When inside of git bash or WSL on windows, you may experience a hang with shell commands.

