### PR TITLE
fix(mason-lspconfig): add missing field `automatic_enable` in setup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -722,6 +722,7 @@ require('lazy').setup({
       require('mason-lspconfig').setup {
         ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
         automatic_installation = false,
+        automatic_enable = true, -- See https://github.com/mason-org/mason-lspconfig.nvim?tab=readme-ov-file#default-configuration
         handlers = {
           function(server_name)
             local server = servers[server_name] or {}


### PR DESCRIPTION
I know this field is set by default, but if it's not explicitly written, Lua will throw an error:

```txt
Diagnostics:
1. Missing required fields in type `MasonLspconfigSettings`: `automatic_enable` [missing-fields]
```