### PR TITLE
feat: add range formatting to formatter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -740,16 +740,6 @@ require('lazy').setup({
     'stevearc/conform.nvim',
     event = { 'BufWritePre' },
     cmd = { 'ConformInfo' },
-    keys = {
-      {
-        '<leader>f',
-        function()
-          require('conform').format { async = true, lsp_format = 'fallback' }
-        end,
-        mode = '',
-        desc = '[F]ormat buffer',
-      },
-    },
     opts = {
       notify_on_error = false,
       format_on_save = function(bufnr)
@@ -774,6 +764,22 @@ require('lazy').setup({
         -- You can use 'stop_after_first' to run the first available formatter from the list
         -- javascript = { "prettierd", "prettier", stop_after_first = true },
       },
+      vim.api.nvim_create_user_command('Format', function(args)
+        local range = nil
+        if args.count ~= -1 then
+          local end_line = vim.api.nvim_buf_gt_lines(0, args.line2 - 1, args.line2, true)[1]
+          range = {
+            start = { args.line1, 0 },
+            ['end'] = { args.line2, end_line:len() },
+          }
+        end
+        require('conform').format {
+          async = true,
+          lsp_format = 'fallback',
+          range = range,
+        }
+      end, { range = true }),
+      vim.keymap.set({ 'n', 'v' }, '<leader>f', '<Cmd>Format<CR>'),
     },
   },
 


### PR DESCRIPTION
Range formatting in Conform is a standout feature that many other formatters lack. However, it was previously missing from kickstart. I’ve now added it, based on the guidance from [this section of the conform.nvim documentation](https://github.com/stevearc/conform.nvim/blob/master/doc/recipes.md#format-command).

This change is fully backward-compatible. Existing users can continue to use `<leader>k` to format the entire file as before. If they select a block of code and press `<leader>k`, only the selected range will be formatted.