### PR TITLE
feat: Enhances breakpoint editing

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -912,7 +912,7 @@ require('lazy').setup({
   --  Here are some example plugins that I've included in the Kickstart repository.
   --  Uncomment any of the lines below to enable them (you will need to restart nvim).
   --
-  -- require 'kickstart.plugins.debug',
+  require 'kickstart.plugins.debug',
   -- require 'kickstart.plugins.indent_line',
   -- require 'kickstart.plugins.lint',
   -- require 'kickstart.plugins.autopairs',

--- a/init.lua
+++ b/init.lua
@@ -912,7 +912,7 @@ require('lazy').setup({
   --  Here are some example plugins that I've included in the Kickstart repository.
   --  Uncomment any of the lines below to enable them (you will need to restart nvim).
   --
-  require 'kickstart.plugins.debug',
+  -- require 'kickstart.plugins.debug',
   -- require 'kickstart.plugins.indent_line',
   -- require 'kickstart.plugins.lint',
   -- require 'kickstart.plugins.autopairs',

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -85,6 +85,10 @@ return {
             prompt = 'Edit Breakpoint',
             format_item = function(item) return ('%s: %s'):format(item, props[item].value) end,
           }, function(choice)
+            if choice == nil then
+              -- User cancelled the selection
+              return
+            end
             props[prompt].setter(vim.fn.input {
               prompt = ('[%s] '):format(prompt),
               default = props[prompt].value,

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -78,13 +78,13 @@ return {
             },
           }
           local menu_options = {}
-          for k, v in pairs(props) do
-            table.insert(menu_options, ('%s: %s'):format(k, v.value))
+          for k, _ in pairs(props) do
+            table.insert(menu_options, k)
           end
           vim.ui.select(menu_options, {
             prompt = 'Edit Breakpoint',
+            format_item = function(item) return ('%s: %s'):format(item, props[item].value) end,
           }, function(choice)
-            local prompt = (tostring(choice)):gsub(':.*', '')
             props[prompt].setter(vim.fn.input {
               prompt = ('[%s] '):format(prompt),
               default = props[prompt].value,

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -44,9 +44,7 @@ return {
           local buf_bps = require('dap.breakpoints').get(vim.fn.bufnr())[vim.fn.bufnr()]
           ---@type dap.SourceBreakpoint
           for _, candidate in ipairs(buf_bps) do
-            if candidate.line and candidate.line == vim.fn.line '.' then
-              return candidate
-            end
+            if candidate.line and candidate.line == vim.fn.line '.' then return candidate end
           end
 
           return { condition = '', logMessage = '', hitCondition = '', line = vim.fn.line '.' }
@@ -58,21 +56,15 @@ return {
           local props = {
             ['Condition'] = {
               value = bp.condition,
-              setter = function(v)
-                bp.condition = v
-              end,
+              setter = function(v) bp.condition = v end,
             },
             ['Hit Condition'] = {
               value = bp.hitCondition,
-              setter = function(v)
-                bp.hitCondition = v
-              end,
+              setter = function(v) bp.hitCondition = v end,
             },
             ['Log Message'] = {
               value = bp.logMessage,
-              setter = function(v)
-                bp.logMessage = v
-              end,
+              setter = function(v) bp.logMessage = v end,
             },
           }
           local menu_options = {}
@@ -81,9 +73,7 @@ return {
           end
           vim.ui.select(menu_options, {
             prompt = 'Edit Breakpoint',
-            format_item = function(item)
-              return ('%s: %s'):format(item, props[item].value)
-            end,
+            format_item = function(item) return ('%s: %s'):format(item, props[item].value) end,
           }, function(choice)
             if choice == nil then
               -- User cancelled the selection

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -89,9 +89,10 @@ return {
               -- User cancelled the selection
               return
             end
-            props[prompt].setter(vim.fn.input {
-              prompt = ('[%s] '):format(prompt),
-              default = props[prompt].value,
+              props[choice].setter(vim.fn.input {
+              prompt = ('[%s] '):format(choice),
+              default = props[choice].value,
+
             })
 
             -- Set breakpoint for current line, with customizations (see h:dap.set_breakpoint())

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -89,10 +89,9 @@ return {
               -- User cancelled the selection
               return
             end
-              props[choice].setter(vim.fn.input {
+            props[choice].setter(vim.fn.input {
               prompt = ('[%s] '):format(choice),
               default = props[choice].value,
-
             })
 
             -- Set breakpoint for current line, with customizations (see h:dap.set_breakpoint())

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -52,7 +52,6 @@ return {
           return { condition = '', logMessage = '', hitCondition = '', line = vim.fn.line '.' }
         end
 
-
         -- Elicit customization via a UI prompt
         ---@param bp dap.SourceBreakpoint a breakpoint
         local function customize_bp(bp)
@@ -82,7 +81,9 @@ return {
           end
           vim.ui.select(menu_options, {
             prompt = 'Edit Breakpoint',
-            format_item = function(item) return ('%s: %s'):format(item, props[item].value) end,
+            format_item = function(item)
+              return ('%s: %s'):format(item, props[item].value)
+            end,
           }, function(choice)
             if choice == nil then
               -- User cancelled the selection

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -36,7 +36,6 @@ return {
     {
       '<leader>B',
       function()
-        require 'dap.protocol'
         local dap = require 'dap'
 
         -- Search for an existing breakpoint on this line in this buffer

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -38,20 +38,21 @@ return {
       function()
         require 'dap.protocol'
         local dap = require 'dap'
+
         -- Search for an existing breakpoint on this line in this buffer
         ---@return dap.SourceBreakpoint bp that was either found, or an empty placeholder
         local function find_bp()
           local buf_bps = require('dap.breakpoints').get(vim.fn.bufnr())[vim.fn.bufnr()]
           ---@type dap.SourceBreakpoint
-          local bp = { condition = '', logMessage = '', hitCondition = '', line = vim.fn.line '.' }
           for _, candidate in ipairs(buf_bps) do
             if candidate.line and candidate.line == vim.fn.line '.' then
-              bp = candidate
-              break
+              return candidate
             end
           end
-          return bp
+
+          return { condition = '', logMessage = '', hitCondition = '', line = vim.fn.line '.' }
         end
+
 
         -- Elicit customization via a UI prompt
         ---@param bp dap.SourceBreakpoint a breakpoint


### PR DESCRIPTION
The keymapping `<leader>B` (in `kickstart.plugins.debug`) is now configured to guide users through the process of adding a `condition`, `hitCondition`, and `logMessage` to a breakpoint.

This also allows attributes that have already been set to be edited, instead of having to start from scratch each time you want to update one of these fields.

These breakpoints will persist for the duration of the session.

Tested with  v0.11.1