### PR TITLE
fix: remove unnecessary diagnostic config lines

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -631,7 +631,6 @@ require('lazy').setup({
       vim.diagnostic.config {
         severity_sort = true,
         float = { border = 'rounded', source = 'if_many' },
-        underline = { severity = vim.diagnostic.severity.ERROR },
         signs = vim.g.have_nerd_font and {
           text = {
             [vim.diagnostic.severity.ERROR] = '󰅚 ',
@@ -643,15 +642,6 @@ require('lazy').setup({
         virtual_text = {
           source = 'if_many',
           spacing = 2,
-          format = function(diagnostic)
-            local diagnostic_message = {
-              [vim.diagnostic.severity.ERROR] = diagnostic.message,
-              [vim.diagnostic.severity.WARN] = diagnostic.message,
-              [vim.diagnostic.severity.INFO] = diagnostic.message,
-              [vim.diagnostic.severity.HINT] = diagnostic.message,
-            }
-            return diagnostic_message[diagnostic.severity]
-          end,
         },
       }
 


### PR DESCRIPTION
The following lines do nothing and can be removed:

```lua
 format = function(diagnostic)
   local diagnostic_message = {
     [vim.diagnostic.severity.ERROR] = diagnostic.message,
     [vim.diagnostic.severity.WARN] = diagnostic.message,
     [vim.diagnostic.severity.INFO] = diagnostic.message,
     [vim.diagnostic.severity.HINT] = diagnostic.message,
   }
   return diagnostic_message[diagnostic.severity]
 end,
```

The following line also serves little purpose, seemingly only reducing the spacing between the end of lines and diagnostic virtual text by two characters, so it can also be removed (EDIT: this change was omitted in the final patch):

```lua
  spacing = 2,
```

The following line causes diagnostics which aren't of severity level error to not have the specific text area underlined. This is less useful than the default of showing underlines for all diagnostic levels, so remove this line as well:

```lua
  underline = { severity = vim.diagnostic.severity.ERROR },
```
