### PR TITLE
fix(mini): disable `mini.surround` by default to preserve native `S` key behavior

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -912,12 +912,19 @@ require('lazy').setup({
       --  - ci'  - [C]hange [I]nside [']quote
       require('mini.ai').setup { n_lines = 500 }
 
+      -- Warning: This plugin sets default keymaps starting with `s`, which override Neovim's native `s`.
+      -- It causes a short delay when pressing `s` due to keymap ambiguity.
+      -- To keep Neovim's original `s` behavior, consider disabling this plugin by default,
+      -- or customize the mappings to use different keys.
+      --
+      -- Use `:help map-ambiguous` to see more information.
+      --
       -- Add/delete/replace surroundings (brackets, quotes, etc.)
       --
       -- - saiw) - [S]urround [A]dd [I]nner [W]ord [)]Paren
       -- - sd'   - [S]urround [D]elete [']quotes
       -- - sr)'  - [S]urround [R]eplace [)] [']
-      require('mini.surround').setup()
+      -- require('mini.surround').setup()
 
       -- Simple and easy statusline.
       --  You could remove this setup call if you don't like it,

--- a/init.lua
+++ b/init.lua
@@ -419,12 +419,19 @@ do
     n_lines = 500,
   }
 
+  -- Warning: This plugin sets default keymaps starting with `s`, which override Neovim's native `s`.
+  -- It causes a short delay when pressing `s` due to keymap ambiguity.
+  -- To keep Neovim's original `s` behavior, consider disabling this plugin by default,
+  -- or customize the mappings to use different keys.
+  --
+  -- Use `:help map-ambiguous` to see more information.
+  --
   -- Add/delete/replace surroundings (brackets, quotes, etc.)
   --
   -- - saiw) - [S]urround [A]dd [I]nner [W]ord [)]Paren
   -- - sd'   - [S]urround [D]elete [']quotes
   -- - sr)'  - [S]urround [R]eplace [)] [']
-  require('mini.surround').setup()
+  -- require('mini.surround').setup()
 
   -- Simple and easy statusline.
   --  You could remove this setup call if you don't like it,


### PR DESCRIPTION
I have confirmed the source code of `mini.surround` (`mini.nvim/lua/mini/surround.lua`). Its `setup` function looks like this:

```lua
MiniSurround.setup = function(config)
  -- ...

  -- Setup config
  config = H.setup_config(config)

  -- Apply config
  H.apply_config(config)

  -- ...
end
```

If the user does not modify `config`, `setup_config` will use the `default_config`:

```lua
H.setup_config = function(config)
  H.check_type('config', config, 'table', true)
  config = vim.tbl_deep_extend('force', vim.deepcopy(H.default_config), config or {})

  -- ...

  return config
end
```

In `default_config.mappings`, multiple mappings start with the character `s`:

```lua
MiniSurround.config = {
  -- ...

  -- Module mappings. Use `''` (empty string) to disable one.
  mappings = {
    add = 'sa',          -- Add surrounding in Normal and Visual modes
    delete = 'sd',       -- Delete surrounding
    find = 'sf',         -- Find surrounding (to the right)
    find_left = 'sF',    -- Find surrounding (to the left)
    highlight = 'sh',    -- Highlight surrounding
    replace = 'sr',      -- Replace surrounding
    update_n_lines = 'sn', -- Update `n_lines`

    suffix_last = 'l',   -- Suffix to search with "prev" method
    suffix_next = 'n',   -- Suffix to search with "next" method
  },

  -- ...
}

H.default_config = vim.deepcopy(MiniSurround.config)
```

These mappings are then applied in the `apply_config` function called after `setup`:

```lua
H.apply_config = function(config)
  MiniSurround.config = config

  local expr_map = function(lhs, rhs, desc) H.map('n', lhs, rhs, { expr = true, desc = desc }) end
  local map = function(lhs, rhs, desc) H.map('n', lhs, rhs, { desc = desc }) end

  --stylua: ignore start
  -- Make regular mappings
  local m = config.mappings

  expr_map(m.add,     H.make_operator('add', nil, true), 'Add surrounding')
  expr_map(m.delete,  H.make_operator('delete'),         'Delete surrounding')
  expr_map(m.replace, H.make_operator('replace'),        'Replace surrounding')

  -- ...
end
```

The Neovim documentation on mappings (`nvim/runtime/doc/map.txt`) in the `map-ambiguous` section states:

> _“When two mappings start with the same sequence of characters, ... Vim is waiting for another character”_:

```help
    							*map-ambiguous*
When two mappings start with the same sequence of characters, they are
ambiguous.  Example: >
	:imap aa foo
	:imap aaa bar
When Vim has read "aa", it will need to get another character to be able to
decide if "aa" or "aaa" should be mapped.  This means that after typing "aa"
that mapping won't get expanded yet, Vim is waiting for another character.
If you type a space, then "foo" will get inserted, plus the space.  If you
type "a", then "bar" will get inserted.
```

I don't need the features this plugin provides, and it significantly disrupts the feel of my normal workflow.

I also see the #1328.

Therefore, I believe this plugin should be disabled by default, with a note explaining that its default mappings interfere with Neovim’s native `S` key behavior. Users should enable it consciously, understanding this limitation, or customize the mappings to avoid conflicts.

I believe beginner-friendly configurations should not include hidden side effects—especially those that override native key behaviors. If there's a strong reason this plugin must be enabled by default, please keep the warning comment to inform users.
