### PR TITLE
Fixed Guess-Indent not loading by default

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -247,8 +247,11 @@ rtp:prepend(lazypath)
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
-  'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
 
+  {
+    'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
+    opts = {},
+  },
   -- NOTE: Plugins can also be added by using a table,
   -- with the first argument being the link and the following
   -- keys can be used to configure plugin behavior/loading/etc.


### PR DESCRIPTION
By default guess-indent is just downloaded and not loaded as it now requires a setup call. 
This fixes it. 