### PR TITLE
use main branch for treesitter to remove depracted vim.validate api

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -940,8 +940,9 @@ require('lazy').setup({
   },
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
+    branch = 'main',
+    lazy = false,
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
     opts = {
       ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },


### PR DESCRIPTION
Recently noticed api deprecated warning while checking `:checkhealth` and opened a ticket with treesitter:
https://github.com/nvim-treesitter/nvim-treesitter/issues/7916

Upon reading further, I found out that they have deprecated the `master` branch and are using `main` -- which removed the deprecated api. I'm updating kickstart to reflect their recommended install settings:
https://github.com/nvim-treesitter/nvim-treesitter/tree/main?tab=readme-ov-file#installation