### PR TITLE
docs: Add documentation for lazy's `init` key

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -267,6 +267,10 @@ require('lazy').setup({
   --        end,
   --    }
   --
+  -- For plugins written in VimScript, use `init = function() ... end` to set
+  -- configuration options, usually in the format `vim.g.*`. This can also
+  -- contain conditionals or any other setup logic you need for the plugin.
+  --
   -- Here is a more advanced example where we pass configuration
   -- options to `gitsigns.nvim`.
   --


### PR DESCRIPTION
Guide users towards lazy's `init` key for plugins written in VimScript.
Alleviates issues like #1570.