### PR TITLE
Update highlight method in init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -215,7 +215,7 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function()
-    vim.hl.on_yank()
+    vim.highlight.on_yank()
   end,
 })
 


### PR DESCRIPTION
In nvim 0.10.2, the vim.hl.on_yank() method has been renamed to vim.highlight.on_yank()

This causes the error
Error detected while processing TextYankPost Autocommands for "*":
