### PR TITLE
feat: improved lsp setup for nvim > 0.11

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -668,7 +668,15 @@ require('lazy').setup({
       --  1) via the mason package manager; or
       --  2) via your system's package manager; or
       --  3) via a release binary from a language server's repo that's accessible somewhere on your system.
-      --
+
+      -- The servers table comprises of the following sub-tables:
+      -- 1. mason
+      -- 2. others
+      -- Both these tables have an identical structure of language server names as keys and
+      -- a table of language server configuration as values.
+      ---@class LspServersConfig
+      ---@field mason table<string, vim.lsp.Config>
+      ---@field others table<string, vim.lsp.Config>
       local servers = {
         --  Add any additional override configuration in any of the following tables. Available keys are:
         --  - cmd (table): Override the default command used to start the server
@@ -736,7 +744,7 @@ require('lazy').setup({
       -- to the default language server configs as provided by nvim-lspconfig or
       -- define a custom server config that's unavailable on nvim-lspconfig.
       for server, config in pairs(vim.tbl_extend('keep', servers.mason, servers.others)) do
-        if vim.fn.empty(config) ~= 1 then
+        if not vim.tbl_isempty(config) then
           vim.lsp.config(server, config)
         end
       end
@@ -748,7 +756,7 @@ require('lazy').setup({
       }
 
       -- Manually run vim.lsp.enable for all language servers that are *not* installed via Mason
-      if vim.fn.empty(servers.others) ~= 1 then
+      if not vim.tbl_isempty(servers.others) then
         vim.lsp.enable(vim.tbl_keys(servers.others))
       end
     end,


### PR DESCRIPTION
The aim of this change is to provide a much clearer distinction between how servers are installed & configured (either directly via Mason or manually). This is a slight alternative to [this](https://github.com/nvim-lua/kickstart.nvim/pull/1475) excellent PR for LSP configuration for neovim > 0.11 onwards.

Since the new `mason-lspconfig` changes enable all servers installed via Mason by default, this might cause confusion for newcomers around server enable if they had a language server installed manually but wanted to re-use the default `nvim-lspconfig` configs. 
Furthermore, not all language servers might be available on Mason for download - however they might already have default configs available on `nvim-lspconfig` for re-use ([example](https://github.com/mason-org/mason-lspconfig.nvim/issues/527)) or have neither available on Mason and `nvim-lspconfig`.

I'm hoping another benefit of this change is that it _should_ also aid in reducing burden on the mason & nvim-lspconfig maintainers when it comes to answering these specific kind of lsp questions.

As always, I'm open to any feedback here. I'm not too fussed if the above linked PR gets merged over this, but wanted to float this idea by the maintainers and community to gather any & all feedback.

Cheers! 🙂

**Minor Changes:**
- Commented and preserved the capabilities step for educational purposes only;
- Auto formatter might have formatted some code, which I quite like tbh . Happy to revert it if needed.