### PR TITLE
feat: add toggle to show/hide diagnostics

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -572,6 +572,11 @@ require('lazy').setup({
           --  the definition of its *type*, not where it was *defined*.
           map('grt', require('telescope.builtin').lsp_type_definitions, '[G]oto [T]ype Definition')
 
+          -- Toggle to show/hide diagnostic messages
+          map('<leader>td', function()
+            vim.diagnostic.enable(not vim.diagnostic.is_enabled())
+          end, '[T]oggle [D]iagnostics')
+
           -- This function resolves a difference between neovim nightly (version 0.11) and stable (version 0.10)
           ---@param client vim.lsp.Client
           ---@param method vim.lsp.protocol.Method


### PR DESCRIPTION
Sometimes, diagnostic messages could be irritating. So it wouldn't hurt to have a toggle to show/hide diagnostics. 