### PR TITLE
fix: update mason-lspconfig setup to not use deprecated handlers

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -721,18 +721,17 @@ require('lazy').setup({
 
       require('mason-lspconfig').setup {
         ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
-        automatic_installation = false,
-        handlers = {
-          function(server_name)
-            local server = servers[server_name] or {}
-            -- This handles overriding only values explicitly passed
-            -- by the server configuration above. Useful when disabling
-            -- certain features of an LSP (for example, turning off formatting for ts_ls)
-            server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-            require('lspconfig')[server_name].setup(server)
-          end,
-        },
+        automatic_enable = false,
       }
+
+      for server_name, server_config in pairs(servers) do
+        local server = server_config or {}
+        -- This handles overriding only values explicitly passed
+        -- by the server configuration above. Useful when disabling
+        -- certain features of an LSP (for example, turning off formatting for ts_ls)
+        server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
+        require('lspconfig')[server_name].setup(server)
+      end
     end,
   },
 


### PR DESCRIPTION
Since the `handlers` setting is removed in [mason-lspconfig v2.0](https://github.com/mason-org/mason-lspconfig.nvim/releases/tag/v2.0.0), I think the following makes sense.

- Remove deprecated `handlers` API and `automatic_installation`

- Set `automatic_enable = false` since setup() is invoked explicitly

