### PR TITLE
fix: guess-indent plugin not working

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -247,7 +247,7 @@ rtp:prepend(lazypath)
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
-  'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
+  { 'NMAC427/guess-indent.nvim', opts = {} }, -- Detect tabstop and shiftwidth automatically
 
   -- NOTE: Plugins can also be added by using a table,
   -- with the first argument being the link and the following


### PR DESCRIPTION
The guess-indent plugin wasn't doing anything after cloning kickstart.nvim - no auto-detection and the `:GuessIndent` command didn't exist.

Turns out the plugin needs `opts = {}` in the lazy config to actually run its setup function. Without it, lazy doesn't bother calling setup, so you get nothing.

Simple fix:
```lua
{ 'NMAC427/guess-indent.nvim', opts = {} }, -- Detect tabstop and shiftwidth automatically
```

Now it actually works like it should.