### PR TITLE
add markdownlint to Mason auto-install

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -716,6 +716,7 @@ require('lazy').setup({
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
         'stylua', -- Used to format Lua code
+        'markdownlint', -- Markdown linter
       })
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 


### PR DESCRIPTION
Fixes #1510  

[lua/kickstart/plugins/lint.lua](https://github.com/nvim-lua/kickstart.nvim/blob/3338d3920620861f8313a2745fd5d2be39f39534/lua/kickstart/plugins/lint.lua#L9) adds `markdownlint` as a linter. But it was not added to list of tools that Mason installed.

This adds markdownlint under `ensure_installed`, which should solve the following error:
```
E5108: Error executing lua: ...hare/nvim/lazy/neo-tree.nvim/lua/neo-tree/utils/init.lua:799: BufEnter Autocommands for "*": Vim(append):Error running markdownlint: ENOENT: no such file or directory
```