### PR TITLE
feat(diagnostics): enhance diagnostics display, dynamic virtual text like VS Code Error Lens

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -628,32 +628,55 @@ require('lazy').setup({
 
       -- Diagnostic Config
       -- See :help vim.diagnostic.Opts
+      local diagnostic_icons = {
+        [vim.diagnostic.severity.ERROR] = '󰅚 ',
+        [vim.diagnostic.severity.WARN] = '󰀪 ',
+        [vim.diagnostic.severity.INFO] = '󰋽 ',
+        [vim.diagnostic.severity.HINT] = '󰌶 ',
+      }
+
       vim.diagnostic.config {
+        update_in_insert = true,
         severity_sort = true,
         float = { border = 'rounded', source = 'if_many' },
-        underline = { severity = vim.diagnostic.severity.ERROR },
-        signs = vim.g.have_nerd_font and {
-          text = {
-            [vim.diagnostic.severity.ERROR] = '󰅚 ',
-            [vim.diagnostic.severity.WARN] = '󰀪 ',
-            [vim.diagnostic.severity.INFO] = '󰋽 ',
-            [vim.diagnostic.severity.HINT] = '󰌶 ',
-          },
-        } or {},
-        virtual_text = {
-          source = 'if_many',
-          spacing = 2,
-          format = function(diagnostic)
-            local diagnostic_message = {
-              [vim.diagnostic.severity.ERROR] = diagnostic.message,
-              [vim.diagnostic.severity.WARN] = diagnostic.message,
-              [vim.diagnostic.severity.INFO] = diagnostic.message,
-              [vim.diagnostic.severity.HINT] = diagnostic.message,
-            }
-            return diagnostic_message[diagnostic.severity]
-          end,
-        },
+        underline = true, -- { severity = vim.diagnostic.severity.ERROR }
+        signs = vim.g.have_nerd_font and { text = diagnostic_icons } or {},
       }
+
+      -- Diagnostic configuration similar to VS Code's Error Lens.
+      -- In insert mode, diagnostics are displayed as inline virtual text.
+      -- In normal mode, diagnostics are shown as virtual lines below the affected lines.
+      ---@param enable boolean
+      local function set_virtual_text(enable)
+        vim.diagnostic.config {
+          virtual_lines = not enable and {
+            format = function(diagnostic)
+              return (diagnostic_icons[diagnostic.severity] or '') .. diagnostic.message
+            end,
+          } or false,
+          virtual_text = enable and {
+            source = 'if_many',
+            spacing = 2,
+            format = function(diagnostic)
+              return (diagnostic_icons[diagnostic.severity] or '') .. diagnostic.message
+            end,
+          } or false,
+        }
+      end
+
+      set_virtual_text(false)
+
+      vim.api.nvim_create_autocmd('InsertEnter', {
+        callback = function()
+          set_virtual_text(true)
+        end,
+      })
+
+      vim.api.nvim_create_autocmd('InsertLeave', {
+        callback = function()
+          set_virtual_text(false)
+        end,
+      })
 
       -- LSP servers and clients are able to communicate to each other what features they support.
       --  By default, Neovim doesn't support everything that is in the LSP specification.

--- a/init.lua
+++ b/init.lua
@@ -672,7 +672,8 @@ require('lazy').setup({
         end,
       })
 
-      vim.api.nvim_create_autocmd('InsertLeave', {
+      vim.api.nvim_create_autocmd('ModeChanged', {
+        pattern = 'i:*',
         callback = function()
           set_virtual_text(false)
         end,


### PR DESCRIPTION
Hi there! 👋

This PR introduces a small enhancement to the diagnostic experience in Neovim.

Instead of keeping the diagnostics always in virtual text or virtual lines, this new setup dynamically switches between the two based on the current mode:

Insert mode: diagnostics are shown inline using virtual text — similar to the behavior of the Error Lens extension in VS Code.

Normal mode: diagnostics switch to virtual lines below the affected code, offering a cleaner and more elegant overview.

This approach provides real-time feedback while coding and a less intrusive display when navigating the code. It's a feature that requires a plugin in editors like VS Code, but here it’s done natively with just a bit of Lua! 😄

I believe this improves the overall developer experience by making diagnostics both more immediate and more readable.

Let me know what you think — open to suggestions!

Thanks 🙏



