### PR TITLE
Telescope config in plugin

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -360,14 +360,15 @@ require('lazy').setup({
 
   { -- Fuzzy Finder (files, lsp, etc)
     'nvim-telescope/telescope.nvim',
-    -- To disable the default Telescope plugin and replace it with
-    -- another picker (like snacks), set enabled to false and
-    -- Enable your replacement picker by requiring it explicitly (e.g., 'kickstart.plugins.snacks')
-    -- By default, Telescope is included and acts as your picker for everything.
+   -- By default, Telescope is included and acts as your picker for everything.
 
-    -- Note: When you customize your config for yourself,
-    -- it’s best to remove the Telescope plugin config entirely
-    -- instead of just disabling it here, to keep your config clean.
+   -- If you would like to switch to a different picker (like snacks, or fzf-lua)
+   -- you can disable the Telescope plugin by setting enabled to false and enable
+   -- your replacement picker by requiring it explicitly (e.g. 'custom.plugins.snacks')
+
+   -- Note: If you customize your config for yourself,
+   -- it’s best to remove the Telescope plugin config entirely
+   -- instead of just disabling it here, to keep your config clean.
     enabled = true,
     event = 'VimEnter',
     dependencies = {

--- a/init.lua
+++ b/init.lua
@@ -360,15 +360,15 @@ require('lazy').setup({
 
   { -- Fuzzy Finder (files, lsp, etc)
     'nvim-telescope/telescope.nvim',
-   -- By default, Telescope is included and acts as your picker for everything.
+    -- By default, Telescope is included and acts as your picker for everything.
 
-   -- If you would like to switch to a different picker (like snacks, or fzf-lua)
-   -- you can disable the Telescope plugin by setting enabled to false and enable
-   -- your replacement picker by requiring it explicitly (e.g. 'custom.plugins.snacks')
+    -- If you would like to switch to a different picker (like snacks, or fzf-lua)
+    -- you can disable the Telescope plugin by setting enabled to false and enable
+    -- your replacement picker by requiring it explicitly (e.g. 'custom.plugins.snacks')
 
-   -- Note: If you customize your config for yourself,
-   -- it’s best to remove the Telescope plugin config entirely
-   -- instead of just disabling it here, to keep your config clean.
+    -- Note: If you customize your config for yourself,
+    -- it’s best to remove the Telescope plugin config entirely
+    -- instead of just disabling it here, to keep your config clean.
     enabled = true,
     event = 'VimEnter',
     dependencies = {

--- a/init.lua
+++ b/init.lua
@@ -437,6 +437,44 @@ require('lazy').setup({
       vim.keymap.set('n', '<leader>s.', builtin.oldfiles, { desc = '[S]earch Recent Files ("." for repeat)' })
       vim.keymap.set('n', '<leader><leader>', builtin.buffers, { desc = '[ ] Find existing buffers' })
 
+      -- This runs on LSP attach per buffer (see main LSP attach function in 'neovim/nvim-lspconfig' config for more info,
+      -- it is better explained there). This is a little bit redundant, but we can switch off telescope for an optional
+      -- picker like snacks more easily when the keymaps are defined in the plugin itself.
+      -- It sets up buffer-local keymaps, autocommands, and other LSP-related settings
+      -- whenever an LSP client attaches to a buffer.
+
+      vim.api.nvim_create_autocmd('LspAttach', {
+        group = vim.api.nvim_create_augroup('telescope-lsp-attach', { clear = true }),
+        callback = function(event)
+          local buf = event.buf
+
+          -- Find references for the word under your cursor.
+          vim.keymap.set('n', 'grr', builtin.lsp_references, { buffer = buf, desc = '[G]oto [R]eferences' })
+
+          -- Jump to the implementation of the word under your cursor.
+          -- Useful when your language has ways of declaring types without an actual implementation.
+          vim.keymap.set('n', 'gri', builtin.lsp_implementations, { buffer = buf, desc = '[G]oto [I]mplementation' })
+
+          -- Jump to the definition of the word under your cursor.
+          -- This is where a variable was first declared, or where a function is defined, etc.
+          -- To jump back, press <C-t>.
+          vim.keymap.set('n', 'grd', builtin.lsp_definitions, { buffer = buf, desc = '[G]oto [D]efinition' })
+
+          -- Fuzzy find all the symbols in your current document.
+          -- Symbols are things like variables, functions, types, etc.
+          vim.keymap.set('n', 'gO', builtin.lsp_document_symbols, { buffer = buf, desc = 'Open Document Symbols' })
+
+          -- Fuzzy find all the symbols in your current workspace.
+          -- Similar to document symbols, except searches over your entire project.
+          vim.keymap.set('n', 'gW', builtin.lsp_dynamic_workspace_symbols, { buffer = buf, desc = 'Open Workspace Symbols' })
+
+          -- Jump to the type of the word under your cursor.
+          -- Useful when you're not sure what type a variable is and you want to see
+          -- the definition of its *type*, not where it was *defined*.
+          vim.keymap.set('n', 'grt', builtin.lsp_type_definitions, { buffer = buf, desc = '[G]oto [T]ype Definition' })
+        end,
+      })
+
       -- Slightly advanced example of overriding default behavior and theme
       vim.keymap.set('n', '<leader>/', function()
         -- You can pass additional configuration to Telescope to change the theme, layout, etc.
@@ -543,34 +581,9 @@ require('lazy').setup({
           -- or a suggestion from your LSP for this to activate.
           map('gra', vim.lsp.buf.code_action, '[G]oto Code [A]ction', { 'n', 'x' })
 
-          -- Find references for the word under your cursor.
-          map('grr', require('telescope.builtin').lsp_references, '[G]oto [R]eferences')
-
-          -- Jump to the implementation of the word under your cursor.
-          --  Useful when your language has ways of declaring types without an actual implementation.
-          map('gri', require('telescope.builtin').lsp_implementations, '[G]oto [I]mplementation')
-
-          -- Jump to the definition of the word under your cursor.
-          --  This is where a variable was first declared, or where a function is defined, etc.
-          --  To jump back, press <C-t>.
-          map('grd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
-
           -- WARN: This is not Goto Definition, this is Goto Declaration.
           --  For example, in C this would take you to the header.
           map('grD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
-
-          -- Fuzzy find all the symbols in your current document.
-          --  Symbols are things like variables, functions, types, etc.
-          map('gO', require('telescope.builtin').lsp_document_symbols, 'Open Document Symbols')
-
-          -- Fuzzy find all the symbols in your current workspace.
-          --  Similar to document symbols, except searches over your entire project.
-          map('gW', require('telescope.builtin').lsp_dynamic_workspace_symbols, 'Open Workspace Symbols')
-
-          -- Jump to the type of the word under your cursor.
-          --  Useful when you're not sure what type a variable is and you want to see
-          --  the definition of its *type*, not where it was *defined*.
-          map('grt', require('telescope.builtin').lsp_type_definitions, '[G]oto [T]ype Definition')
 
           -- This function resolves a difference between neovim nightly (version 0.11) and stable (version 0.10)
           ---@param client vim.lsp.Client

--- a/init.lua
+++ b/init.lua
@@ -360,6 +360,15 @@ require('lazy').setup({
 
   { -- Fuzzy Finder (files, lsp, etc)
     'nvim-telescope/telescope.nvim',
+    -- To disable the default Telescope plugin and replace it with
+    -- another picker (like snacks), set enabled to false and
+    -- Enable your replacement picker by requiring it explicitly (e.g., 'kickstart.plugins.snacks')
+    -- By default, Telescope is included and acts as your picker for everything.
+
+    -- Note: When you customize your config for yourself,
+    -- it’s best to remove the Telescope plugin config entirely
+    -- instead of just disabling it here, to keep your config clean.
+    enabled = true,
     event = 'VimEnter',
     dependencies = {
       'nvim-lua/plenary.nvim',


### PR DESCRIPTION
I previously added these changes to another pr of mine, but after some thought, im pulling those changes apart, so we can decide on replacing the picker, more infos here: https://github.com/nvim-lua/kickstart.nvim/pull/1632

this pr just moves some telescope specific config from the lspconfig to the telescope plugin config declaration, just to entangle those two.