### PR TITLE
Enhance Kickstart.nvim UX with Buffer Completions, Options, and Autocommands

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -166,6 +166,15 @@ vim.o.scrolloff = 10
 -- See `:help 'confirm'`
 vim.o.confirm = true
 
+-- Enable undo/redo changes even after closing and reopening a file
+vim.opt.undofile = true
+
+-- Enable smooth scrolling
+vim.opt.smoothscroll = true
+
+-- Highlight max chars per line
+-- vim.opt.colorcolumn = '100'
+
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`
 
@@ -183,6 +192,9 @@ vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagn
 -- NOTE: This won't work in all terminal emulators/tmux/etc. Try your own mapping
 -- or just use <C-\><C-n> to exit terminal mode
 vim.keymap.set('t', '<Esc><Esc>', '<C-\\><C-n>', { desc = 'Exit terminal mode' })
+
+-- Close current buffer
+vim.keymap.set('n', '<leader>Q', ':bd<CR>', { desc = 'Close current buffer' })
 
 -- TIP: Disable arrow keys in normal mode
 -- vim.keymap.set('n', '<left>', '<cmd>echo "Use h to move!!"<CR>')
@@ -215,9 +227,45 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function()
-    vim.hl.on_yank()
+    vim.hl.on_yank { timeout = 200 }
   end,
 })
+
+-- Restore cursor position on file open
+vim.api.nvim_create_autocmd('BufReadPost', {
+  desc = 'Restore cursor position on file open',
+  group = vim.api.nvim_create_augroup('kickstart-restore-cursor', { clear = true }),
+  pattern = '*',
+  callback = function()
+    local line = vim.fn.line '\'"'
+    if line > 1 and line <= vim.fn.line '$' then
+      vim.cmd 'normal! g\'"'
+    end
+  end,
+})
+
+-- auto-create missing dirs when saving a file
+vim.api.nvim_create_autocmd('BufWritePre', {
+  desc = 'Auto-create missing dirs when saving a file',
+  group = vim.api.nvim_create_augroup('kickstart-auto-create-dir', { clear = true }),
+  pattern = '*',
+  callback = function()
+    local dir = vim.fn.expand '<afile>:p:h'
+    if vim.fn.isdirectory(dir) == 0 then
+      vim.fn.mkdir(dir, 'p')
+    end
+  end,
+})
+
+-- disable automatic comment on newline
+-- vim.api.nvim_create_autocmd('FileType', {
+--   desc = 'Disable automatic comment on newline',
+--   group = vim.api.nvim_create_augroup('kickstart-disable-auto-comment', { clear = true }),
+--   pattern = '*',
+--   callback = function()
+--     vim.opt_local.formatoptions:remove { 'c', 'r', 'o' }
+--   end,
+-- })
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
@@ -854,9 +902,21 @@ require('lazy').setup({
       },
 
       sources = {
-        default = { 'lsp', 'path', 'snippets', 'lazydev' },
+        default = { 'lsp', 'path', 'snippets', 'lazydev', 'buffer' },
         providers = {
           lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
+          buffer = {
+            score_offset = -1,
+            filter = function(buffer)
+              -- Filetypes for which buffer completions are enabled; add filetypes to extend
+              local enabled_filetypes = {
+                'markdown',
+                'text',
+              }
+              local filetype = vim.bo[buffer].filetype
+              return vim.tbl_contains(enabled_filetypes, filetype)
+            end,
+          },
         },
       },
 


### PR DESCRIPTION
This pull request enhances the `kickstart.nvim` configuration by adding features to improve user experience, focusing on session persistence, navigation, and completion functionality. The changes maintain the project's minimal and extensible philosophy, targeting common workflows, particularly for markdown and text files.

---

## Changes

### Options

* `vim.opt.undofile = true`: Enables **persistent undo history** across sessions, allowing users to undo/redo changes after reopening files.
* `vim.opt.smoothscroll = true`: Enables **smooth line-by-line scrolling** (Neovim 0.10+), improving navigation in large files and completion menus.
* `vim.opt.colorcolumn = '100'`: Commented out; would highlight column 100 to indicate maximum line length, left disabled for minimalism.

### Keymaps

* Added `<leader>Q` mapping to **close the current buffer** (`:bd<CR>`), providing a convenient shortcut for buffer management.

### Autocommands

* Modified `TextYankPost`: Added `timeout = 200` to limit yank highlight duration, **reducing visual distraction**.
* Added `BufReadPost`: **Restores cursor position on file open** for all files (`pattern = '*'`), enhancing session continuity.
* Added `BufWritePre`: Automatically **creates missing directories when saving files**, improving usability for new file paths.
* Commented out `FileType`: Would disable automatic comment continuation for all filetypes, left optional for user customization.

### blink.cmp Configuration

* Added `buffer` source to `sources.default` in `blink.cmp`, with a filter restricting completions to **markdown and text filetypes**. This provides relevant word completions from open buffers for documentation-focused workflows.