### PR TITLE
Enhance Kickstart.nvim UX with Buffer Completions, Options, and Autocommands

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -170,7 +170,7 @@ vim.o.confirm = true
 vim.o.wrap = false
 
 -- Highlight max chars per line
--- vim.o.colorcolumn = '100'
+-- vim.o.colorcolumn = '120'
 
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`
@@ -253,16 +253,6 @@ vim.api.nvim_create_autocmd('BufWritePre', {
     end
   end,
 })
-
--- disable automatic comment on newline
--- vim.api.nvim_create_autocmd('FileType', {
---   desc = 'Disable automatic comment on newline',
---   group = vim.api.nvim_create_augroup('kickstart-disable-auto-comment', { clear = true }),
---   pattern = '*',
---   callback = function()
---     vim.opt_local.formatoptions:remove { 'c', 'r', 'o' }
---   end,
--- })
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info

--- a/init.lua
+++ b/init.lua
@@ -167,13 +167,13 @@ vim.o.scrolloff = 10
 vim.o.confirm = true
 
 -- Enable undo/redo changes even after closing and reopening a file
-vim.opt.undofile = true
+vim.o.undofile = true
 
--- Enable smooth scrolling
-vim.opt.smoothscroll = true
+-- Disable line wrapping
+vim.o.wrap = false
 
 -- Highlight max chars per line
--- vim.opt.colorcolumn = '100'
+-- vim.o.colorcolumn = '100'
 
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`

--- a/init.lua
+++ b/init.lua
@@ -906,14 +906,15 @@ require('lazy').setup({
         providers = {
           lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
           buffer = {
-            score_offset = -1,
-            filter = function(buffer)
-              -- Filetypes for which buffer completions are enabled; add filetypes to extend
+            -- Make buffer compeletions appear at the end.
+            score_offset = -100,
+            enabled = function()
+              -- Filetypes for which buffer completions are enabled; add filetypes to extend:
               local enabled_filetypes = {
                 'markdown',
                 'text',
               }
-              local filetype = vim.bo[buffer].filetype
+              local filetype = vim.bo.filetype
               return vim.tbl_contains(enabled_filetypes, filetype)
             end,
           },

--- a/init.lua
+++ b/init.lua
@@ -166,6 +166,15 @@ vim.o.scrolloff = 10
 -- See `:help 'confirm'`
 vim.o.confirm = true
 
+-- Enable undo/redo changes even after closing and reopening a file
+vim.opt.undofile = true
+
+-- Enable smooth scrolling
+vim.opt.smoothscroll = true
+
+-- Highlight max chars per line
+-- vim.opt.colorcolumn = '100'
+
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`
 
@@ -183,6 +192,9 @@ vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagn
 -- NOTE: This won't work in all terminal emulators/tmux/etc. Try your own mapping
 -- or just use <C-\><C-n> to exit terminal mode
 vim.keymap.set('t', '<Esc><Esc>', '<C-\\><C-n>', { desc = 'Exit terminal mode' })
+
+-- Close current buffer
+vim.keymap.set('n', '<leader>Q', ':bd<CR>', { desc = 'Close current buffer' })
 
 -- TIP: Disable arrow keys in normal mode
 -- vim.keymap.set('n', '<left>', '<cmd>echo "Use h to move!!"<CR>')
@@ -215,9 +227,45 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function()
-    vim.hl.on_yank()
+    vim.hl.on_yank { timeout = 200 }
   end,
 })
+
+-- Restore cursor position on file open
+vim.api.nvim_create_autocmd('BufReadPost', {
+  desc = 'Restore cursor position on file open',
+  group = vim.api.nvim_create_augroup('kickstart-restore-cursor', { clear = true }),
+  pattern = '*',
+  callback = function()
+    local line = vim.fn.line '\'"'
+    if line > 1 and line <= vim.fn.line '$' then
+      vim.cmd 'normal! g\'"'
+    end
+  end,
+})
+
+-- auto-create missing dirs when saving a file
+vim.api.nvim_create_autocmd('BufWritePre', {
+  desc = 'Auto-create missing dirs when saving a file',
+  group = vim.api.nvim_create_augroup('kickstart-auto-create-dir', { clear = true }),
+  pattern = '*',
+  callback = function()
+    local dir = vim.fn.expand '<afile>:p:h'
+    if vim.fn.isdirectory(dir) == 0 then
+      vim.fn.mkdir(dir, 'p')
+    end
+  end,
+})
+
+-- disable automatic comment on newline
+-- vim.api.nvim_create_autocmd('FileType', {
+--   desc = 'Disable automatic comment on newline',
+--   group = vim.api.nvim_create_augroup('kickstart-disable-auto-comment', { clear = true }),
+--   pattern = '*',
+--   callback = function()
+--     vim.opt_local.formatoptions:remove { 'c', 'r', 'o' }
+--   end,
+-- })
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
@@ -854,9 +902,21 @@ require('lazy').setup({
       },
 
       sources = {
-        default = { 'lsp', 'path', 'snippets', 'lazydev' },
+        default = { 'lsp', 'path', 'snippets', 'lazydev', 'buffer' },
         providers = {
           lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
+          buffer = {
+            score_offset = -1,
+            filter = function(buffer)
+              -- Filetypes for which buffer completions are enabled; add filetypes to extend
+              local enabled_filetypes = {
+                'markdown',
+                'text',
+              }
+              local filetype = vim.bo[buffer].filetype
+              return vim.tbl_contains(enabled_filetypes, filetype)
+            end,
+          },
         },
       },
 

--- a/init.lua
+++ b/init.lua
@@ -121,7 +121,7 @@ end)
 -- Enable break indent
 vim.o.breakindent = true
 
--- Save undo history
+-- Enable undo/redo changes even after closing and reopening a file
 vim.o.undofile = true
 
 -- Case-insensitive searching UNLESS \C or one or more capital letters in the search term
@@ -165,9 +165,6 @@ vim.o.scrolloff = 10
 -- instead raise a dialog asking if you wish to save the current file(s)
 -- See `:help 'confirm'`
 vim.o.confirm = true
-
--- Enable undo/redo changes even after closing and reopening a file
-vim.o.undofile = true
 
 -- Disable line wrapping
 vim.o.wrap = false


### PR DESCRIPTION
This pull request aims to enhances the `kickstart.nvim` configuration by integrating features that directly improve user experience, with a core focus on **session persistence**, **efficient navigation**, and **smarter completion functionality**. The changes meticulously maintain the project's foundational minimal and extensible philosophy.

---

## Detailed Changes

### ⚙️ Options

* `vim.opt.undofile = true`: **Enables persistent undo history** across Neovim sessions. This enhancement allows users to undo and redo changes even after closing and reopening files, boosting productivity and safety.
* `vim.opt.smoothscroll = true`: Activates **smooth, line-by-line scrolling** (requires Neovim 0.10+). This visual improvement enhances readability and navigation, especially within large files and when traversing completion menus.
* `vim.opt.colorcolumn = '100'`: This option is intentionally commented out. If uncommented, it would visually highlight column 100 to indicate a preferred maximum line length, but it remains disabled to uphold the configuration's minimalist design principle.

### ⌨️ Keymaps

* Added `<leader>Q` mapping: Introduces a convenient, quick shortcut to **close the current buffer** (`:bd<CR>`). This streamlines buffer management and improves workflow efficiency.

### 🔄 Autocommands

* Modified `TextYankPost`: Enhanced by adding `timeout = 200`. This modification effectively **limits the duration of the yank highlight**, reducing visual distraction. Furthermore, the explicit `timeout` value offers users a clear point of customization to increase or decrease the highlight duration based on their personal preference, promoting a more tailored experience.
* Added `BufReadPost`: Implements an autocommand to **restore the cursor position on file open** (`pattern = '*'`). This ensures session continuity improves user experience by returning users directly to their last editing location across all file types.
* Added `BufWritePre`: Automatically **creates any missing parent directories when saving a file**. This eliminates a common friction point, improving usability when creating new files with nested paths.
* Commented out `FileType`: This autocommand, if enabled, would disable automatic comment continuation for all filetypes. It remains commented out, offering users the flexibility to enable or disable it based on their specific coding conventions and preferences.

### 💡 `blink.cmp` Configuration

* Integrated `buffer` source into `sources.default`: This addition to `blink.cmp` provides **relevant word completions directly from currently open buffers**. The source is further refined with a filter restricting completions to **user-chosen filetypes**, currently pre-configured for **markdown and text files**.
