### PR TITLE
Switch nvim-treesitter to the new `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ External Requirements:
 - Basic utils: `git`, `make`, `unzip`, C Compiler (`gcc`)
 - [ripgrep](https://github.com/BurntSushi/ripgrep#installation),
   [fd-find](https://github.com/sharkdp/fd#installation)
+- [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md#installation)
 - Clipboard tool (xclip/xsel/win32yank or other depending on the platform)
 - A [Nerd Font](https://www.nerdfonts.com/): optional, provides various icons
   - if you have it set `vim.g.have_nerd_font` in `init.lua` to true
@@ -185,7 +186,7 @@ winget install --accept-source-agreements chocolatey.chocolatey
 2. install all requirements using choco, exit the previous cmd and
 open a new one so that choco path is set, and run in cmd as **admin**:
 ```
-choco install -y neovim git ripgrep wget fd unzip gzip mingw make
+choco install -y neovim git ripgrep wget fd unzip gzip mingw make tree-sitter
 ```
 </details>
 <details><summary>WSL (Windows Subsystem for Linux)</summary>
@@ -195,7 +196,7 @@ wsl --install
 wsl
 sudo add-apt-repository ppa:neovim-ppa/unstable -y
 sudo apt update
-sudo apt install make gcc ripgrep unzip git xclip neovim
+sudo apt install make gcc ripgrep fd-find treesitter-cli unzip git xclip neovim
 ```
 </details>
 
@@ -205,14 +206,14 @@ sudo apt install make gcc ripgrep unzip git xclip neovim
 ```
 sudo add-apt-repository ppa:neovim-ppa/unstable -y
 sudo apt update
-sudo apt install make gcc ripgrep unzip git xclip neovim
+sudo apt install make gcc ripgrep fd-find treesitter-cli unzip git xclip neovim
 ```
 </details>
 <details><summary>Debian Install Steps</summary>
 
 ```
 sudo apt update
-sudo apt install make gcc ripgrep unzip git xclip curl
+sudo apt install make gcc ripgrep fd-find tree-sitter-cli unzip git xclip curl
 
 # Now we install nvim
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
@@ -228,14 +229,14 @@ sudo ln -sf /opt/nvim-linux-x86_64/bin/nvim /usr/local/bin/
 <details><summary>Fedora Install Steps</summary>
 
 ```
-sudo dnf install -y gcc make git ripgrep fd-find unzip neovim
+sudo dnf install -y gcc make git ripgrep fd-find tree-sitter-cli unzip neovim
 ```
 </details>
 
 <details><summary>Arch Install Steps</summary>
 
 ```
-sudo pacman -S --noconfirm --needed gcc make git ripgrep fd unzip neovim
+sudo pacman -S --noconfirm --needed gcc make git ripgrep fd tree-sitter-cli unzip neovim
 ```
 </details>
 

--- a/init.lua
+++ b/init.lua
@@ -940,28 +940,34 @@ require('lazy').setup({
   },
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
+    lazy = false,
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
-    -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
-    opts = {
-      ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
-      -- Autoinstall languages that are not installed
-      auto_install = true,
-      highlight = {
-        enable = true,
-        -- Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.
-        --  If you are experiencing weird indenting issues, add the language to
-        --  the list of additional_vim_regex_highlighting and disabled languages for indent.
-        additional_vim_regex_highlighting = { 'ruby' },
-      },
-      indent = { enable = true, disable = { 'ruby' } },
-    },
+    branch = 'main',
+    -- [[ Configure Treesitter ]] See `:help nvim-treesitter-intro`
+    config = function()
+      local parsers = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' }
+      require('nvim-treesitter').install(parsers)
+
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = parsers,
+        callback = function()
+          -- enables syntax highlighting and other treesitter features
+          vim.treesitter.start()
+
+          -- enables treesitter based folds
+          -- for more info on folds see `:help folds`
+          -- vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+
+          -- enables treesitter based indentation
+          vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        end,
+      })
+    end,
     -- There are additional nvim-treesitter modules that you can use to interact
     -- with nvim-treesitter. You should go explore a few and see what interests you:
     --
-    --    - Incremental selection: Included, see `:help nvim-treesitter-incremental-selection-mod`
     --    - Show your current context: https://github.com/nvim-treesitter/nvim-treesitter-context
-    --    - Treesitter + textobjects: https://github.com/nvim-treesitter/nvim-treesitter-textobjects
+    --    - Treesitter + textobjects: https://github.com/nvim-treesitter/nvim-treesitter-textobjects (using the `main` branch)
   },
 
   -- The following comments only work if you have downloaded the kickstart repo, not just copy pasted the

--- a/init.lua
+++ b/init.lua
@@ -945,23 +945,54 @@ require('lazy').setup({
     branch = 'main',
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter-intro`
     config = function()
-      local parsers = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' }
-      require('nvim-treesitter').install(parsers)
+      ---@param buf integer
+      ---@param language string
+      ---@return boolean
+      local function treesitter_attach(buf, language)
+        -- check if parser exists before starting highlighter
+        if not vim.treesitter.language.add(language) then
+          return false
+        end
+        -- enables syntax highlighting and other treesitter features
+        vim.treesitter.start(buf, language)
 
+        -- enables treesitter based folds
+        -- for more info on folds see `:help folds`
+        -- vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+
+        -- enables treesitter based indentation
+        vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        return true
+      end
+
+      local available_parsers = require('nvim-treesitter.config').get_available()
       vim.api.nvim_create_autocmd('FileType', {
-        pattern = parsers,
-        callback = function()
-          -- enables syntax highlighting and other treesitter features
-          vim.treesitter.start()
+        callback = function(args)
+          local buf, filetype = args.buf, args.match
+          local language = vim.treesitter.language.get_lang(filetype)
+          if not language then
+            return
+          end
 
-          -- enables treesitter based folds
-          -- for more info on folds see `:help folds`
-          -- vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+          if not (treesitter_attach(buf, language) or vim.tbl_contains(available_parsers, language)) then
+            return
+          end
 
-          -- enables treesitter based indentation
-          vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+          -- automaically install parser for missing languages
+          -- attempt to install even if it is available accoring to `vim.treesitter.langauge.add()`,
+          -- to ensure the latest version is installed using `nvim-treesitter`, instead of the outdated vendored parser
+          if not vim.tbl_contains(require('nvim-treesitter.config').get_installed 'parsers', language) then
+            -- attempt to start highlighter after installing missing language
+            require('nvim-treesitter.install').install(language):await(function()
+              treesitter_attach(buf, language)
+            end)
+          end
         end,
       })
+
+      -- ensure basic parser are installed
+      local parsers = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' }
+      require('nvim-treesitter').install(parsers)
     end,
     -- There are additional nvim-treesitter modules that you can use to interact
     -- with nvim-treesitter. You should go explore a few and see what interests you:

--- a/init.lua
+++ b/init.lua
@@ -972,20 +972,19 @@ require('lazy').setup({
             return
           end
 
-          -- try to enable treesitter features in case the parser exists but is not available from `nvim-treesitter`
-          if not vim.tbl_contains(available_parsers, language) then
-            treesitter_try_attach(buf, language)
-            return
-          end
-
-          -- if a parser is available in `nvim-treesitter` enable it after ensuring it is installed
           local installed_parsers = require('nvim-treesitter').get_installed 'parsers'
+
           if vim.tbl_contains(installed_parsers, language) then
+            -- enable the parser if it is installed
             treesitter_try_attach(buf, language)
-          else
+          elseif vim.tbl_contains(available_parsers, language) then
+            -- if a parser is available in `nvim-treesitter` enable it after ensuring it is installed
             require('nvim-treesitter').install(language):await(function()
               treesitter_try_attach(buf, language)
             end)
+          else
+            -- try to enable treesitter features in case the parser exists but is not available from `nvim-treesitter`
+            treesitter_try_attach(buf, language)
           end
         end,
       })


### PR DESCRIPTION
As described in `nvim-treesitter`'s README:
> The `master` branch is frozen and provided for backward compatibility only. All future updates happen on the [`main` branch](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/README.md), which will become the default branch in the future.

This is a proactive branch to switch to the new branch.
I have been using it for a couple of month and it seems pretty stable to me, though I'm not sure if this is really ready to be merged right now.
There maybe features that are not yet supported (or will never be) like incremental selection.
Does anyone else have experience with this transition, and can give feedback?

PS, I also added support for treesitter based folds, but left it commented out. Let me know if you think I should enable it in this PR.