### PR TITLE
fix(lsp): updated config for  mason to v2

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -700,6 +700,15 @@ require('lazy').setup({
         },
       }
 
+      -- The following loop will configure each server with the capabilities we defined above.
+      -- This will ensure that all servers have the same base configuration, but also
+      -- allow for server-specific overrides.
+      for server_name, server_config in pairs(servers) do
+        server_config.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server_config.capabilities or {})
+        vim.lsp.config(server_name, server_config)
+        vim.lsp.enable(server_name)
+      end
+
       -- Ensure the servers and tools above are installed
       --
       -- To check the current status of installed tools and/or manually install
@@ -718,21 +727,6 @@ require('lazy').setup({
         'stylua', -- Used to format Lua code
       })
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
-
-      require('mason-lspconfig').setup {
-        ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
-        automatic_installation = false,
-        handlers = {
-          function(server_name)
-            local server = servers[server_name] or {}
-            -- This handles overriding only values explicitly passed
-            -- by the server configuration above. Useful when disabling
-            -- certain features of an LSP (for example, turning off formatting for ts_ls)
-            server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-            require('lspconfig')[server_name].setup(server)
-          end,
-        },
-      }
     end,
   },
 


### PR DESCRIPTION
This pull request updates the LSP configuration to align with the changes in ```mason-lspconfig.nvim``` ```v2.0.0```.

The ```handlers``` feature has been removed from ```mason-lspconfig.nvim```. The PR adapts to that change by iterating through the servers table and calling ```require('lspconfig')[server_name].setup(server_config)``` for each server. This approach maintains the use of the ```nvim-lspconfig``` API for server configuration.

This change simplifies the LSP configuration and ensures compatibility with the latest version of ```mason-lspconfig.nvim```.



