### PR TITLE
chore: fix help tag

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -148,7 +148,7 @@ vim.o.splitbelow = true
 --  Notice listchars is set using `vim.opt` instead of `vim.o`.
 --  It is very similar to `vim.o` but offers an interface for conveniently interacting with tables.
 --   See `:help lua-options`
---   and `:help lua-options-guide`
+--   and `:help lua-guide-options`
 vim.o.list = true
 vim.opt.listchars = { tab = '» ', trail = '·', nbsp = '␣' }
 


### PR DESCRIPTION
Hey all! Thanks so much for kickstart.nvim.

I noticed `:help lua-options-guide` doesn't exist, while `:help lua-guide-options` does with info relevant to that section (`vim.o` vs `vim.opt`).