### PR TITLE
Fix: Prevent mason-lspconfig crash + highlight key fix

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -215,7 +215,7 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function()
-    vim.hl.on_yank()
+    vim.highlight.on_yank()
   end,
 })
 
@@ -722,6 +722,7 @@ require('lazy').setup({
       require('mason-lspconfig').setup {
         ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
         automatic_installation = false,
+        automatic_enable = false,
         handlers = {
           function(server_name)
             local server = servers[server_name] or {}


### PR DESCRIPTION
1. Fix mason-lspconfig crash Explicitly sets: automatic_enable = false This prevents a known issue in recent versions of mason-lspconfig where a nil `enable()` function causes a crash. Keeping this disabled in Kickstart improves stability for new users.

2. Fix highlight key typo A previous commit changed `highlight` to `hl` in the `on_yank` autocmd, but related code still used `highlight`, causing inconsistency. This commit restores consistency. Feel free to revise the preferred style.

