### PR TITLE
Add 'gr' group to which-keys

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -347,6 +347,7 @@ require('lazy').setup({
         { '<leader>s', group = '[S]earch' },
         { '<leader>t', group = '[T]oggle' },
         { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } },
+        { 'gr', group = 'LSP Actions', mode = { 'n' } },
       },
     },
   },


### PR DESCRIPTION
Adds 'gr' to which-keys documentation, so users can see that LSP actions are grouped after 'gr' key binds.

It used to be directly under 'g', which required no additional grouping info on which-keys. See #1427 for further explanation on the key binds change.

