### PR TITLE
Migrate mason-lspconfig handlers to vim.lsp.config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -700,6 +700,16 @@ require('lazy').setup({
         },
       }
 
+      -- Now setup those configurations
+      for name, config in pairs(servers) do
+        local config = config or {}
+        -- This handles overriding only values explicitly passed
+        -- by the server configuration above. Useful when disabling
+        -- certain features of an LSP (for example, turning off formatting for ts_ls)
+        config.capabilities = vim.tbl_deep_extend('force', {}, capabilities, config.capabilities or {})
+        vim.lsp.config(name, config)
+      end
+
       -- Ensure the servers and tools above are installed
       --
       -- To check the current status of installed tools and/or manually install
@@ -722,16 +732,6 @@ require('lazy').setup({
       require('mason-lspconfig').setup {
         ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
         automatic_installation = false,
-        handlers = {
-          function(server_name)
-            local server = servers[server_name] or {}
-            -- This handles overriding only values explicitly passed
-            -- by the server configuration above. Useful when disabling
-            -- certain features of an LSP (for example, turning off formatting for ts_ls)
-            server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-            require('lspconfig')[server_name].setup(server)
-          end,
-        },
       }
     end,
   },


### PR DESCRIPTION
As stated in the [`mason-lspconfig` changelog](https://github.com/mason-org/mason-lspconfig.nvim/blob/6bdb14f230de0904229ec367b410fb817e59b072/CHANGELOG.md), they **removed the `handlers` configuration** in their plugin, making Kickstart no longer responsible for automatic LSP server configuration.
```
### Removed Features

- Removed the `handlers` setting and `.setup_handlers()` function.
- Replaced by the new native `vim.lsp.config()` API.
- Introduced a new `automatic_enable` setting.

```