### PR TITLE
config guess-indent in setup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -249,7 +249,9 @@ require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
   {
     'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
-    config = function() require('guess-indent').setup {} end,
+    config = function()
+      require('guess-indent').setup {}
+    end,
   },
 
   -- NOTE: Plugins can also be added by using a table,

--- a/init.lua
+++ b/init.lua
@@ -247,7 +247,10 @@ rtp:prepend(lazypath)
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
-  'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
+  {
+    'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
+    config = function() require('guess-indent').setup {} end,
+  },
 
   -- NOTE: Plugins can also be added by using a table,
   -- with the first argument being the link and the following


### PR DESCRIPTION
***************************************************************************
**NOTE**
Please verify that the `base repository` above has the intended destination!
Github by default opens Pull Requests against the parent of a forked repository.
If this is your personal fork and you didn't intend to open a PR for contribution
to the original project then adjust the `base repository` accordingly.
**************************************************************************
It seems that `guess-indent` doesn't work unless you assign `config` manually, here is what I get from https://github.com/NMAC427/guess-indent.nvim:
```
-- using packer.nvim
use {
  'nmac427/guess-indent.nvim',
  config = function() require('guess-indent').setup {} end,
}
```
And after define `config` property, it works well for me.