### PR TITLE
fix: migrate to native vim.lsp.config for nvim 0.11+ (#1776)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -729,7 +729,8 @@ require('lazy').setup({
             -- by the server configuration above. Useful when disabling
             -- certain features of an LSP (for example, turning off formatting for ts_ls)
             server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-            require('lspconfig')[server_name].setup(server)
+            vim.lsp.config(server_name, server)
+            vim.lsp.enable(server_name)
           end,
         },
       }


### PR DESCRIPTION
Replaces the deprecated `require('lspconfig')[name].setup()` pattern with Neovim's native `vim.lsp.config` and `vim.lsp.enable` APIs within the Mason handler.

`nvim-lspconfig` is deprecating its internal framework logic in favor of Neovim's core LSP management. This change resolves the deprecation warning and ensures compatibility with nvim-lspconfig v3.0.0.

References:
- https://github.com/neovim/nvim-lspconfig/commit/23d2875d4c95f4fe527d4f3575438453b0f8dc48
- https://vi.stackexchange.com/questions/47239/how-to-properly-migrate-from-deprecated-lspconfig-setup-to-vim-lsp-config
