### PR TITLE
fix: remove incorrect nvim-treesitter.configs main module reference

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -941,7 +941,7 @@ require('lazy').setup({
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
+    -- main = 'nvim-treesitter.configs', -- Sets main module to use for opts
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
     opts = {
       ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },


### PR DESCRIPTION
## Summary
- Remove incorrect `main = 'nvim-treesitter.configs'` reference
- The actual module file is `config.lua` (singular), not `configs.lua`
- This fixes "module 'nvim-treesitter.configs' not found" error on startup
- lazy.nvim will correctly load plugin using default module path

## Issue
Fixes #1732 and resolves widespread issue where users get:
```
Failed to run `config` for nvim-treesitter
module 'nvim-treesitter.configs' not found
```

## Root Cause
nvim-treesitter plugin renamed its main module from `configs.lua` to `config.lua`, but kickstart.nvim still references the old module name.

## Testing
- Verified plugin loads correctly without main specification
- Confirmed nvim-treesitter functionality works as expected
- No breaking changes to existing configuration options