### PR TITLE
Treesitter fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test.sh
 nvim
 
 spell/
+lazy-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ test.sh
 nvim
 
 spell/
-lazy-lock.json

--- a/init.lua
+++ b/init.lua
@@ -940,6 +940,7 @@ require('lazy').setup({
   },
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
+    branch = "master",
     build = ':TSUpdate',
     main = 'nvim-treesitter.configs', -- Sets main module to use for opts
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter`


### PR DESCRIPTION
Updated nvim-treesitter config to follow the stable 'master' branch (as opposed to the now default 'main' branch) as a temporary fix.