### PR TITLE
Remove lazy-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ test.sh
 nvim
 
 spell/
-lazy-lock.json


### PR DESCRIPTION
Remove lazy-lock.json from .gitignore

***************************************************************************
**NOTE**
Please verify that the `base repository` above has the intended destination!
Github by default opens Pull Requests against the parent of a forked repository.
If this is your personal fork and you didn't intend to open a PR for contribution
to the original project then adjust the `base repository` accordingly.
**************************************************************************

