### PR TITLE
Set vim.env.TERM to 'dumb' to remove ANSI formatting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -166,6 +166,9 @@ vim.o.scrolloff = 10
 -- See `:help 'confirm'`
 vim.o.confirm = true
 
+-- Removes ANSI formatting characters (like `\033[31m`) printed by shell escape commands (like `:!ls`)
+vim.env.TERM = 'dumb'
+
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`
 


### PR DESCRIPTION
# Problem

When using `:!ls` command, the output given by the shell may include ANSI formatting characters that does not get processed.

```
:!ls

    Directory: C:\Users\한울\AppData\Local\nvim

^[[32;1mMode   ^[[0m^[[32;1m              LastWriteTime^[[0m ^[[32;1;3m        Length^[[0m^[[32;1m Name^[[0m
^[[32;1m----   ^[[0m ^[[32;1m             -------------^[[0m ^[[32;1m        ------^[[0m ^[[32;1m----^[[0m
d----        2025-12-17 오후 10:50                ^[[44;1m.github^[[0m
d----        2025-12-17 오후 10:50                ^[[44;1mdoc^[[0m
```

# Solution

Set vim.env.TERM to dumb to let shell ignore formatting when directing its stdout to neovim by adding the lines below:

```lua
-- Removes ANSI formatting characters (like `\033[31m`) printed by shell escape commands (like `:!ls`)
vim.env.TERM = 'dumb'
```