### PR TITLE
Fix main module path for nvim-treesitter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -941,7 +941,7 @@ require('lazy').setup({
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
+    main = 'nvim-treesitter.config', -- Sets main module to use for opts
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
     opts = {
       ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },


### PR DESCRIPTION

<img width="1163" height="416" alt="Screenshot 2025-12-29 231704" src="https://github.com/user-attachments/assets/3a42b429-61a0-4644-8b5d-1732e0435b65" />
The above error is I was getting while installing kickstart.nvim in windows terminal (Git bash), changing `nvim-treesitter.configs` to `nvim-treesitter.config` fixes the error.

***************************************************************************
**NOTE**
Please verify that the `base repository` above has the intended destination!
Github by default opens Pull Requests against the parent of a forked repository.
If this is your personal fork and you didn't intend to open a PR for contribution
to the original project then adjust the `base repository` accordingly.
**************************************************************************

