### PR TITLE
Fix nvim-treesitter lazy.nvim config by removing invalid 'main' field

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -941,7 +941,6 @@ require('lazy').setup({
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
     -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
     opts = {
       ensure_installed = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },


### PR DESCRIPTION
### Problem

On Windows, setting `main = 'nvim-treesitter.configs'` causes lazy.nvim to attempt
`require('nvim-treesitter.configs')`, but this module does not exist in
nvim-treesitter. As a result, Neovim fails to load the plugin.

Other platforms may not trigger the same error, but the configuration
is invalid and can cause issues.

### Solution

Remove the `main` field and rely on lazy.nvim’s default behavior, which
correctly calls `require('nvim-treesitter.configs').setup(opts)`.

### Result

Neovim starts normally on Windows (and other platforms) and treesitter
is configured as expected.