### PR TITLE
docs: add tree-sitter-cli and node as requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ External Requirements:
 - Basic utils: `git`, `make`, `unzip`, C Compiler (`gcc`)
 - [ripgrep](https://github.com/BurntSushi/ripgrep#installation),
   [fd-find](https://github.com/sharkdp/fd#installation)
+- [`tree-sitter-cli`](https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md) - For syntax highlighting (required by `nvim-treesitter`)
+- [`node`](https://nodejs.org/en/download) - Required by `tree-sitter-cli` to generate parsers
 - Clipboard tool (xclip/xsel/win32yank or other depending on the platform)
 - A [Nerd Font](https://www.nerdfonts.com/): optional, provides various icons
   - if you have it set `vim.g.have_nerd_font` in `init.lua` to true

--- a/lua/kickstart/health.lua
+++ b/lua/kickstart/health.lua
@@ -20,14 +20,22 @@ local check_version = function()
 end
 
 local check_external_reqs = function()
-  -- Basic utils: `git`, `make`, `unzip`
-  for _, exe in ipairs { 'git', 'make', 'unzip', 'rg' } do
+  -- Basic utils: `git`, `make`, `unzip`, `node`
+  for _, exe in ipairs { 'git', 'make', 'unzip', 'rg', 'node' } do
     local is_executable = vim.fn.executable(exe) == 1
     if is_executable then
       vim.health.ok(string.format("Found executable: '%s'", exe))
     else
       vim.health.warn(string.format("Could not find executable: '%s'", exe))
     end
+  end
+
+  -- Special check for tree-sitter CLI (handles naming variations)
+  local ts_exe = vim.fn.executable 'tree-sitter-cli' == 1 and 'tree-sitter-cli' or 'tree-sitter'
+  if vim.fn.executable(ts_exe) == 1 then
+    vim.health.ok(string.format("Found executable: '%s'", ts_exe))
+  else
+    vim.health.warn(string.format("Could not find executable: '%s'", ts_exe))
   end
 
   return true


### PR DESCRIPTION
The nvim-treesitter rewrite (main branch) now requires the CLI and Node to generate parsers.

