### PR TITLE
Fix treesitter setup and Mason

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -614,7 +614,7 @@ require('lazy').setup({
       -- You can press `g?` for help in this menu.
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
-        'lua_ls', -- Lua Language server
+        'lua-language-server', -- Mason package for lua_ls
         'stylua', -- Used to format Lua code
         -- You can add other tools here that you want Mason to install
       })
@@ -853,7 +853,11 @@ require('lazy').setup({
     'nvim-treesitter/nvim-treesitter',
     config = function()
       local filetypes = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' }
-      require('nvim-treesitter').install(filetypes)
+      require('nvim-treesitter.configs').setup {
+        ensure_installed = filetypes,
+        auto_install = true,
+        highlight = { enable = true },
+      }
       vim.api.nvim_create_autocmd('FileType', {
         pattern = filetypes,
         callback = function() vim.treesitter.start() end,


### PR DESCRIPTION
Lua package

Apply the Neovim config fixes for current plugin APIs:
  replace deprecated nvim-treesitter install call with configs.setup

## Errors on Debian:
```
                                                                             
                                                                                           
  /home/mbergo/.config/nvim/init.lua:856: attempt to call field 'install' (a nil 
  value)                                                                         
            
                                                                                 
                                                                                 
            
  # stacktrace:                                                                  
                                                                                 
            
    - .config/nvim/init.lua:856 _in_ **config**                                  
                                                                                 
            
    - .config/nvim/init.lua:257"
```

and

```
❯ Error executing vim.schedule lua callback: 
  ...l/share/nvim/lazy/mason.nvim/lua/mason
  -registry/init.lua:32: Cannot find package "lua_ls".                           
       
  stack traceback:                                                               
       
          [C]: in function 'error'                                               
       
          ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:32: in 
  function 
  'get_package'                                                                  
       
          ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:269: in 
  function
   'callback'                                                                    
       
          ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:153: in 
  function
   'refresh'                                                                     
       
          ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:345: in 
  function
   ''                                                                            
       
          vim/_editor.lua: in function ''                                        
       
          vim/_editor.lua: in function <vim/_editor.lua:0>
```

@tjdevries, big fan, my friend.