### PR TITLE
fixed lua language server name and setup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -614,7 +614,7 @@ require('lazy').setup({
       -- You can press `g?` for help in this menu.
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
-        'lua_ls', -- Lua Language server
+        'lua-language-server', -- Lua Language server
         'stylua', -- Used to format Lua code
         -- You can add other tools here that you want Mason to install
       })
@@ -853,7 +853,7 @@ require('lazy').setup({
     'nvim-treesitter/nvim-treesitter',
     config = function()
       local filetypes = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' }
-      require('nvim-treesitter').install(filetypes)
+      require('nvim-treesitter').setup(filetypes)
       vim.api.nvim_create_autocmd('FileType', {
         pattern = filetypes,
         callback = function() vim.treesitter.start() end,


### PR DESCRIPTION
Was facing these issues:
```
Failed to run `config` for nvim-treesitter

/home/d/.config/nvim/init.lua:856: attempt to call field 'install' (a nil value)

# stacktrace:
  - init.lua:856 _in_ **config**
  - init.lua:257
Press ENTER or type command to continue
Error executing vim.schedule lua callback: ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:32: Cannot find package
"lua_ls".
stack traceback:
        [C]: in function 'error'
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:32: in function 'get_package'
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:269: in function 'callback'
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:155: in function 'refresh'
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:345: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
Press ENTER or type command to continue
```
Changing these 2 lines fixed it.