### PR TITLE
Clarify comment in .gitignore for lazy-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ nvim
 
 spell/
 
-# You can uncomment this yourself if you want to lock the lazy-lock.json,
-# but for kickstart, it makes sense to leave it ignored.
+# You likely want to comment this, since it's recommended to track lazy-lock.json in version
+# control, see https://lazy.folke.io/usage/lockfile
+# For kickstart, it makes sense to leave it ignored.
 lazy-lock.json
 
 .DS_Store


### PR DESCRIPTION
The current comment in .gitignore for lazy-lock.json suggests to uncomment it yourself, but you actually need to comment it instead.

This change modifies the comment to clarify the recommended approach for kickstart users.

