### PR TITLE
Remove blink from nvim-lspconfig dependencies

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -500,9 +500,6 @@ require('lazy').setup({
 
       -- Useful status updates for LSP.
       { 'j-hui/fidget.nvim', opts = {} },
-
-      -- Allows extra capabilities provided by blink.cmp
-      'saghen/blink.cmp',
     },
     config = function()
       -- Brief aside: **What is LSP?**


### PR DESCRIPTION
Blink is no longer needed in lsp config and was removed in this [commit](https://github.com/nvim-lua/kickstart.nvim/commit/1f4c21f4637eb7af77c34ac87c739e378043a336)

