### PR TITLE
Add feat: Ctrl-Backspace keymap for word deletion

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -171,6 +171,9 @@ vim.o.confirm = true
 --  See `:help hlsearch`
 vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
 
+-- Delete a word on Ctrl-Backspace
+vim.keymap.set('i', '<C-H>', '<C-w>')
+
 -- Diagnostic Config & Keymaps
 -- See :help vim.diagnostic.Opts
 vim.diagnostic.config {


### PR DESCRIPTION
Keymap for word deletion that is triggered by **Ctrl-Backspace.**

Thanks.