### PR TITLE
fix #1933: Allow mason to automatically enable its installed servers

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -496,7 +496,6 @@ require('lazy').setup({
       },
       -- Maps LSP server names between nvim-lspconfig and Mason package names.
       'mason-org/mason-lspconfig.nvim',
-      'WhoIsSethDaniel/mason-tool-installer.nvim',
 
       -- Useful status updates for LSP.
       { 'j-hui/fidget.nvim', opts = {} },
@@ -655,7 +654,7 @@ require('lazy').setup({
         -- You can add other tools here that you want Mason to install
       })
 
-      require('mason-tool-installer').setup { ensure_installed = ensure_installed }
+      require('mason-lspconfig').setup { ensure_installed = ensure_installed }
 
       for name, server in pairs(servers) do
         vim.lsp.config(name, server)


### PR DESCRIPTION
using `require('mason-lspconfig').setup()` now autoenables the lsps which mason has installed
this pr will preserve the approach previous kickstart used to have of auto enabling them

also `mason-lspconfig` now has the ability to autoinstall the listed servers so the mason-tool-installer plugin is redundant now

[Link to `ensure_installed` ability in mason-lspconfig](https://github.com/mason-org/mason-lspconfig.nvim?tab=readme-ov-file#configuration)