### PR TITLE
Track lazy-lock.json in forks by default; enforce via CI and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Any PR that inadvertently includes lazy-lock.json will require maintainer review.
+# See .github/workflows/check-no-lockfile.yml for the CI enforcement.
+lazy-lock.json @oriori1703 @tjdevries

--- a/.github/workflows/check-no-lockfile.yml
+++ b/.github/workflows/check-no-lockfile.yml
@@ -1,0 +1,24 @@
+# Prevent lazy-lock.json from being accidentally included in upstream PRs.
+# Fork users are encouraged to track this file in their own repos.
+# Contributors working directly against this repo should add lazy-lock.json
+# to .git/info/exclude to ignore it locally without touching .gitignore.
+name: Check No Lockfile
+on: pull_request_target
+
+jobs:
+  check-no-lockfile:
+    if: github.repository == 'nvim-lua/kickstart.nvim'
+    name: Check No Lockfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Check lazy-lock.json not included
+        run: |
+          if [ -f "lazy-lock.json" ]; then
+            echo "::error::lazy-lock.json should not be committed to the upstream repo."
+            echo "To ignore it locally without modifying .gitignore, add it to .git/info/exclude."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,9 @@ nvim
 
 spell/
 
-# In your personal fork, you likely want to comment this, since it's recommended to track
-# lazy-lock.json in version control - see https://lazy.folke.io/usage/lockfile
-# For the official `nvim-lua/kickstart.nvim` git repository, we leave it ignored to avoid unneeded
-# merge conflicts.
-lazy-lock.json
+# lazy-lock.json is intentionally not ignored here so that forks can track it
+# without needing to modify this file - see https://lazy.folke.io/usage/lockfile
+# Contributors working directly against this repo who do not want to track it
+# can add it to .git/info/exclude instead.
 
 .DS_Store


### PR DESCRIPTION
Closes #1962.

- Remove `lazy-lock.json` from `.gitignore` so fork users can track it without editing any files
- Add `.github/CODEOWNERS` entry to flag any PR that inadvertently includes the file
- Add CI workflow as a hard block — fails if `lazy-lock.json` is present in a PR (upstream repo only)
- Update the `.gitignore` comment to direct contributors to `.git/info/exclude` for local suppression