### PR TITLE
fix: deprecated diagnostic jumping config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -184,7 +184,15 @@ vim.diagnostic.config {
   virtual_lines = false, -- Text shows up underneath the line, with virtual lines
 
   -- Auto open the float, so you can easily read the errors when jumping with `[d` and `]d`
-  jump = { float = true },
+  jump = {
+    on_jump = function(_, bufnr)
+      vim.diagnostic.open_float {
+        bufnr = bufnr,
+        scope = 'cursor',
+        focus = false,
+      }
+    end,
+  },
 }
 
 vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })

--- a/init.lua
+++ b/init.lua
@@ -192,7 +192,15 @@ do
     virtual_lines = false, -- Text shows up underneath the line, with virtual lines
 
     -- Auto open the float, so you can easily read the errors when jumping with `[d` and `]d`
-    jump = { float = true },
+    jump = {
+      on_jump = function(_, bufnr)
+        vim.diagnostic.open_float {
+          bufnr = bufnr,
+          scope = 'cursor',
+          focus = false,
+        }
+      end,
+    },
   }
 
   vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })

--- a/lua/kickstart/health.lua
+++ b/lua/kickstart/health.lua
@@ -12,7 +12,7 @@ local check_version = function()
     return
   end
 
-  if vim.version.ge(vim.version(), '0.11') then
+  if vim.version.ge(vim.version(), '0.12') then
     vim.health.ok(string.format("Neovim version is: '%s'", verstr))
   else
     vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))


### PR DESCRIPTION
`opts.jump.float` is deprecated as of the 0.12 release. To confirm, use the kickstart config and run: 
`:checkhealth vim.deprecated`

- ⚠️ WARNING opts.jump.float is deprecated. Feature will be removed in Nvim 0.14
  - ADVICE:
    - use opts.jump.on_jump instead.

This also bumps the minimum version to 0.12

