### PR TITLE
fix(treesitter): Add indentation fallback

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -891,8 +891,12 @@ require('lazy').setup({
         -- vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
         -- vim.wo.foldmethod = 'expr'
 
+        -- check if treesitter indentation is available for this language, and if so enable it
+        -- in case there is no indent query, the indentexpr will fallback to the vim's built in one
+        local has_indent_query = vim.treesitter.query.get(language, 'indent') ~= nil
+
         -- enables treesitter based indentation
-        vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        if has_indent_query then vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()" end
       end
 
       local available_parsers = require('nvim-treesitter').get_available()


### PR DESCRIPTION
Add fallback for languages which does not have `indent` query available, therefore neovim will use the built in indentation functions.

For example C# currently does not have treesitter indent query available

```lua
Installed languages     H L F I J ~
- bash                  ✓ ✓ ✓ ✓ ✓
- c                     ✓ ✓ ✓ ✓ ✓
- c_sharp               ✓ ✓ ✓ . ✓
- diff                  ✓ . ✓ . ✓
- dtd                   ✓ ✓ ✓ . ✓
```

Output from checking `indentexpr` for C# file after change
```lua
20:13:49 msg_show.list_cmd   set indentexpr?   indentexpr=GetCSIndent(v:lnum)
```
