### PR TITLE
feat: remap treesitter incremental selection not to collide with mini.ai

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -921,6 +921,25 @@ require('lazy').setup({
           end
         end,
       })
+
+      -- Treesitter incremental selection, see `:help treesitter-incremental-selection`
+      -- Note: the default keymaps `an` and `in` collide with mini.ai, so we remap them below
+      -- Try putting your cursor in one of the lines below and typing `v+` (then continue to type `+` or `-`)
+      vim.keymap.set({ 'x', 'o' }, '+', function()
+        if vim.treesitter.get_parser(nil, nil, { error = false }) then
+          require('vim.treesitter._select').select_parent(vim.v.count1)
+        else
+          vim.lsp.buf.selection_range(vim.v.count1)
+        end
+      end, { desc = 'Select parent (outer) node' })
+
+      vim.keymap.set({ 'x', 'o' }, '-', function()
+        if vim.treesitter.get_parser(nil, nil, { error = false }) then
+          require('vim.treesitter._select').select_child(vim.v.count1)
+        else
+          vim.lsp.buf.selection_range(-vim.v.count1)
+        end
+      end, { desc = 'Select child (inner) node' })
     end,
   },
 


### PR DESCRIPTION
Treesitter incremental selection is pretty cool, let's make sure people have it right out the gate.

This PR requires neovim 0.12, and addresses an issue in #1971

These mappings are yoinked from core [here](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/_core/defaults.lua#L469) 

