### PR TITLE
feat: add LSP document color style configuration

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -585,6 +585,13 @@ require('lazy').setup({
             })
           end
 
+          -- Set your preferred document color highlight style in the document if the LSP supports it and Neovim is >=0.12
+          --    See `:help lsp-document_color` for more information.
+          if client and client:supports_method('textDocument/documentColor', event.buf) and vim.fn.has 'nvim-0.12' == 1 then
+            -- Possible presets for the `style` option: 'background', 'foreground', 'virtual', or a literal string
+            vim.lsp.document_color.enable(true, nil, { style = '󰌁 ' })
+          end
+
           -- The following code creates a keymap to toggle inlay hints in your
           -- code, if the language server you are using supports them
           --


### PR DESCRIPTION
I think this is a cool feature that more people should be aware of when using Neovim.

It adds document color highlights if the LSP supports it and if Neovim is gratear than v0.12.

The highlights will look something like this, depending on the style preset used.

### Foreground

<img width="887" height="1219" alt="nvim-document-color-1" src="https://github.com/user-attachments/assets/7810fef5-4333-4fc2-b5bd-4a69068cc30f" />

### Background

<img width="694" height="1224" alt="nvim-document-color-3" src="https://github.com/user-attachments/assets/bf65ff53-f754-4ffa-9f97-365118aaeb5d" />

### Literal string

<img width="790" height="1222" alt="nvim-document-color-2" src="https://github.com/user-attachments/assets/dea1f16d-d699-44a7-a94f-7aeeb4812f51" />
