### PR TITLE
fix: which-key breaks `vim.v.count` in visual mode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -375,6 +375,11 @@ do
       { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } }, -- Enable gitsigns recommended keymaps first
       { 'gr', group = 'LSP Actions', mode = { 'n' } },
     },
+    -- Do not trigger in visual mode to avoid a known bug
+    -- https://github.com/folke/which-key.nvim/issues/824
+    triggers = {
+      { '<auto>', mode = 'nisotc' },
+    },
   }
 
   -- [[ Colorscheme ]]


### PR DESCRIPTION
**Reproduction**

1. Go to this line (currently 901 in master), and put your cursor on the first `'`. I marked cursor pos with `| |`
`local parsers = { |'|bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' }`
2. Type `v]n2]n`
Confirm that `'diff'` is selected when in reality `'html'` should be selected
3. To confirm this fixes it, checkout this branch and then do the above steps again

Here is the [issue](https://github.com/folke/which-key.nvim/issues/824) where it is reported upstream

fixes: #2047