### PR TITLE
chore: note which-key <leader>h gitsigns dependecy

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -372,7 +372,7 @@ do
     spec = {
       { '<leader>s', group = '[S]earch', mode = { 'n', 'v' } },
       { '<leader>t', group = '[T]oggle' },
-      { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } }, -- Enable gitsigns recommended keymaps first
+      { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } }, -- Depends on gitsigns plugin. Uncomment in Section 9
       { 'gr', group = 'LSP Actions', mode = { 'n' } },
     },
   }


### PR DESCRIPTION
No explicit instruction on what to do and where.
```lua
{ '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } }, -- Enable gitsigns recommended keymaps first
```
The instruction should include: This requires gitsigns. First, uncomment to add that plugin.