### PR TITLE
fix(lsp): migrate to vim.lsp.config and clear startup crash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -27,18 +27,19 @@ External Requirements:
 - Clipboard tool (xclip/xsel/win32yank or other depending on the platform)
 - A [Nerd Font](https://www.nerdfonts.com/): optional, provides various icons
   - if you have it set `vim.g.have_nerd_font` in `init.lua` to true
+- Emoji fonts (Ubuntu only, and only if you want emoji!) `sudo apt install fonts-noto-color-emoji`
 - Language Setup:
   - If you want to write Typescript, you need `npm`
   - If you want to write Golang, you will need `go`
   - etc.
 
-> **NOTE**
+> [!NOTE]
 > See [Install Recipes](#Install-Recipes) for additional Windows and Linux specific notes
 > and quick install snippets
 
 ### Install Kickstart
 
-> **NOTE**
+> [!NOTE]
 > [Backup](#FAQ) your previous configuration (if any exists)
 
 Neovim's configurations are located under the following paths, depending on your OS:
@@ -55,7 +56,7 @@ Neovim's configurations are located under the following paths, depending on your
 so that you have your own copy that you can modify, then install by cloning the
 fork to your machine using one of the commands below, depending on your OS.
 
-> **NOTE**
+> [!NOTE]
 > Your fork's URL will be something like this:
 > `https://github.com/<your_github_username>/kickstart.nvim.git`
 
@@ -64,7 +65,8 @@ too - it's ignored in the kickstart repo to make maintenance easier, but it's
 [recommended to track it in version control](https://lazy.folke.io/usage/lockfile).
 
 #### Clone kickstart.nvim
-> **NOTE**
+
+> [!NOTE]
 > If following the recommended step above (i.e., forking the repo), replace
 > `nvim-lua` with `<your_github_username>` in the commands below
 
@@ -212,14 +214,14 @@ sudo apt update
 sudo apt install make gcc ripgrep unzip git xclip curl
 
 # Now we install nvim
-curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz
-sudo rm -rf /opt/nvim-linux64
-sudo mkdir -p /opt/nvim-linux64
-sudo chmod a+rX /opt/nvim-linux64
-sudo tar -C /opt -xzf nvim-linux64.tar.gz
+curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
+sudo rm -rf /opt/nvim-linux-x86_64
+sudo mkdir -p /opt/nvim-linux-x86_64
+sudo chmod a+rX /opt/nvim-linux-x86_64
+sudo tar -C /opt -xzf nvim-linux-x86_64.tar.gz
 
 # make it available in /usr/local/bin, distro installs to /usr/bin
-sudo ln -sf /opt/nvim-linux64/bin/nvim /usr/local/bin/
+sudo ln -sf /opt/nvim-linux-x86_64/bin/nvim /usr/local/bin/
 ```
 </details>
 <details><summary>Fedora Install Steps</summary>

--- a/init.lua
+++ b/init.lua
@@ -1,89 +1,3 @@
---[[
-
-=====================================================================
-==================== READ THIS BEFORE CONTINUING ====================
-=====================================================================
-========                                    .-----.          ========
-========         .----------------------.   | === |          ========
-========         |.-""""""""""""""""""-.|   |-----|          ========
-========         ||                    ||   | === |          ========
-========         ||   KICKSTART.NVIM   ||   |-----|          ========
-========         ||                    ||   | === |          ========
-========         ||                    ||   |-----|          ========
-========         ||:Tutor              ||   |:::::|          ========
-========         |'-..................-'|   |____o|          ========
-========         `"")----------------(""`   ___________      ========
-========        /::::::::::|  |::::::::::\  \ no mouse \     ========
-========       /:::========|  |==hjkl==:::\  \ required \    ========
-========      '""""""""""""'  '""""""""""""'  '""""""""""'   ========
-========                                                     ========
-=====================================================================
-=====================================================================
-
-What is Kickstart?
-
-  Kickstart.nvim is *not* a distribution.
-
-  Kickstart.nvim is a starting point for your own configuration.
-    The goal is that you can read every line of code, top-to-bottom, understand
-    what your configuration is doing, and modify it to suit your needs.
-
-    Once you've done that, you can start exploring, configuring and tinkering to
-    make Neovim your own! That might mean leaving Kickstart just the way it is for a while
-    or immediately breaking it into modular pieces. It's up to you!
-
-    If you don't know anything about Lua, I recommend taking some time to read through
-    a guide. One possible example which will only take 10-15 minutes:
-      - https://learnxinyminutes.com/docs/lua/
-
-    After understanding a bit more about Lua, you can use `:help lua-guide` as a
-    reference for how Neovim integrates Lua.
-    - :help lua-guide
-    - (or HTML version): https://neovim.io/doc/user/lua-guide.html
-
-Kickstart Guide:
-
-  TODO: The very first thing you should do is to run the command `:Tutor` in Neovim.
-
-    If you don't know what this means, type the following:
-      - <escape key>
-      - :
-      - Tutor
-      - <enter key>
-
-    (If you already know the Neovim basics, you can skip this step.)
-
-  Once you've completed that, you can continue working through **AND READING** the rest
-  of the kickstart init.lua.
-
-  Next, run AND READ `:help`.
-    This will open up a help window with some basic information
-    about reading, navigating and searching the builtin help documentation.
-
-    This should be the first place you go to look when you're stuck or confused
-    with something. It's one of my favorite Neovim features.
-
-    MOST IMPORTANTLY, we provide a keymap "<space>sh" to [s]earch the [h]elp documentation,
-    which is very useful when you're not exactly sure of what you're looking for.
-
-  I have left several `:help X` comments throughout the init.lua
-    These are hints about where to find more information about the relevant settings,
-    plugins or Neovim features used in Kickstart.
-
-   NOTE: Look for lines like this
-
-    Throughout the file. These are for you, the reader, to help you understand what is happening.
-    Feel free to delete them once you know what you're doing, but they should serve as a guide
-    for when you are first encountering a few different constructs in your Neovim config.
-
-If you experience any errors while trying to install kickstart, run `:checkhealth` for more info.
-
-I hope you enjoy your Neovim journey,
-- TJ
-
-P.S. You can delete this when you're done too. It's your config now! :)
---]]
-
 -- Set <space> as the leader key
 -- See `:help mapleader`
 --  NOTE: Must happen before plugins are loaded (otherwise wrong leader will be used)
@@ -91,7 +5,7 @@ vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
 
 -- Set to true if you have a Nerd Font installed and selected in the terminal
-vim.g.have_nerd_font = false
+vim.g.have_nerd_font = true
 
 -- [[ Setting options ]]
 -- See `:help vim.opt`
@@ -102,7 +16,7 @@ vim.g.have_nerd_font = false
 vim.opt.number = true
 -- You can also add relative line numbers, to help with jumping.
 --  Experiment for yourself to see if you like it!
--- vim.opt.relativenumber = true
+vim.opt.relativenumber = false
 
 -- Enable mouse mode, can be useful for resizing splits for example!
 vim.opt.mouse = 'a'
@@ -175,10 +89,10 @@ vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagn
 vim.keymap.set('t', '<Esc><Esc>', '<C-\\><C-n>', { desc = 'Exit terminal mode' })
 
 -- TIP: Disable arrow keys in normal mode
--- vim.keymap.set('n', '<left>', '<cmd>echo "Use h to move!!"<CR>')
--- vim.keymap.set('n', '<right>', '<cmd>echo "Use l to move!!"<CR>')
--- vim.keymap.set('n', '<up>', '<cmd>echo "Use k to move!!"<CR>')
--- vim.keymap.set('n', '<down>', '<cmd>echo "Use j to move!!"<CR>')
+vim.keymap.set('n', '<left>', '<cmd>echo "Use h to move!!"<CR>')
+vim.keymap.set('n', '<right>', '<cmd>echo "Use l to move!!"<CR>')
+vim.keymap.set('n', '<up>', '<cmd>echo "Use k to move!!"<CR>')
+vim.keymap.set('n', '<down>', '<cmd>echo "Use j to move!!"<CR>')
 
 -- Keybinds to make split navigation easier.
 --  Use CTRL+<hjkl> to switch between windows
@@ -202,6 +116,13 @@ vim.api.nvim_create_autocmd('TextYankPost', {
     vim.highlight.on_yank()
   end,
 })
+
+vim.api.nvim_create_autocmd('FileType', {
+    pattern = { 'markdown' },
+    callback = function()
+      vim.wo.conceallevel = 2
+    end,
+  })
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
@@ -628,7 +549,6 @@ require('lazy').setup({
         -- But for many setups, the LSP (`ts_ls`) will work just fine
         -- ts_ls = {},
         --
-
         lua_ls = {
           -- cmd = { ... },
           -- filetypes = { ... },
@@ -640,6 +560,28 @@ require('lazy').setup({
               },
               -- You can toggle below to ignore Lua_LS's noisy `missing-fields` warnings
               -- diagnostics = { disable = { 'missing-fields' } },
+            },
+          },
+        },
+      }
+      require('lspconfig').ruff.setup {
+        init_options = {
+          settings = {
+            -- Ruff language server settings go here
+          },
+        },
+      }
+
+      require('lspconfig').basedpyright.setup {
+        settings = {
+          pyright = {
+            -- Using Ruff's import organizer
+            disableOrganizeImports = true,
+          },
+          python = {
+            analysis = {
+              -- Ignore all files for analysis to exclusively use Ruff for linting
+              ignore = { '*' },
             },
           },
         },
@@ -849,7 +791,7 @@ require('lazy').setup({
       -- Load the colorscheme here.
       -- Like many other themes, this one has different styles, and you could load
       -- any other, such as 'tokyonight-storm', 'tokyonight-moon', or 'tokyonight-day'.
-      vim.cmd.colorscheme 'tokyonight-night'
+      vim.cmd.colorscheme 'tokyonight'
 
       -- You can configure highlights by doing something like:
       vim.cmd.hi 'Comment gui=none'
@@ -942,7 +884,7 @@ require('lazy').setup({
   --    This is the easiest way to modularize your config.
   --
   --  Uncomment the following line and add your plugins to `lua/custom/plugins/*.lua` to get going.
-  -- { import = 'custom.plugins' },
+  { import = 'custom.plugins' },
   --
   -- For additional information with loading, sourcing and examples see `:help lazy.nvim-🔌-plugin-spec`
   -- Or use telescope!

--- a/init.lua
+++ b/init.lua
@@ -70,6 +70,11 @@ vim.opt.cursorline = true
 -- Minimal number of screen lines to keep above and below the cursor.
 vim.opt.scrolloff = 10
 
+-- if performing an operation that would fail due to unsaved changes in the buffer (like `:q`),
+-- instead raise a dialog asking if you wish to save the current file(s)
+-- See `:help 'confirm'`
+vim.opt.confirm = true
+
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`
 
@@ -102,6 +107,12 @@ vim.keymap.set('n', '<C-h>', '<C-w><C-h>', { desc = 'Move focus to the left wind
 vim.keymap.set('n', '<C-l>', '<C-w><C-l>', { desc = 'Move focus to the right window' })
 vim.keymap.set('n', '<C-j>', '<C-w><C-j>', { desc = 'Move focus to the lower window' })
 vim.keymap.set('n', '<C-k>', '<C-w><C-k>', { desc = 'Move focus to the upper window' })
+
+-- NOTE: Some terminals have colliding keymaps or are not able to send distinct keycodes
+-- vim.keymap.set("n", "<C-S-h>", "<C-w>H", { desc = "Move window to the left" })
+-- vim.keymap.set("n", "<C-S-l>", "<C-w>L", { desc = "Move window to the right" })
+-- vim.keymap.set("n", "<C-S-j>", "<C-w>J", { desc = "Move window to the lower" })
+-- vim.keymap.set("n", "<C-S-k>", "<C-w>K", { desc = "Move window to the upper" })
 
 -- [[ Basic Autocommands ]]
 --  See `:help lua-guide-autocommands`
@@ -155,12 +166,22 @@ require('lazy').setup({
   -- with the first argument being the link and the following
   -- keys can be used to configure plugin behavior/loading/etc.
   --
-  -- Use `opts = {}` to force a plugin to be loaded.
+  -- Use `opts = {}` to automatically pass options to a plugin's `setup()` function, forcing the plugin to be loaded.
   --
 
+  -- Alternatively, use `config = function() ... end` for full control over the configuration.
+  -- If you prefer to call `setup` explicitly, use:
+  --    {
+  --        'lewis6991/gitsigns.nvim',
+  --        config = function()
+  --            require('gitsigns').setup({
+  --                -- Your gitsigns configuration here
+  --            })
+  --        end,
+  --    }
+  --
   -- Here is a more advanced example where we pass configuration
-  -- options to `gitsigns.nvim`. This is equivalent to the following Lua:
-  --    require('gitsigns').setup({ ... })
+  -- options to `gitsigns.nvim`.
   --
   -- See `:help gitsigns` to understand what the configuration keys do
   { -- Adds git related signs to the gutter, as well as utilities for managing changes
@@ -236,11 +257,7 @@ require('lazy').setup({
 
       -- Document existing key chains
       spec = {
-        { '<leader>c', group = '[C]ode', mode = { 'n', 'x' } },
-        { '<leader>d', group = '[D]ocument' },
-        { '<leader>r', group = '[R]ename' },
         { '<leader>s', group = '[S]earch' },
-        { '<leader>w', group = '[W]orkspace' },
         { '<leader>t', group = '[T]oggle' },
         { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } },
       },
@@ -257,7 +274,6 @@ require('lazy').setup({
   { -- Fuzzy Finder (files, lsp, etc)
     'nvim-telescope/telescope.nvim',
     event = 'VimEnter',
-    branch = '0.1.x',
     dependencies = {
       'nvim-lua/plenary.nvim',
       { -- If encountering errors, see telescope-fzf-native README for installation instructions
@@ -386,8 +402,8 @@ require('lazy').setup({
       -- Useful status updates for LSP.
       { 'j-hui/fidget.nvim', opts = {} },
 
-      -- Allows extra capabilities provided by nvim-cmp
-      'hrsh7th/cmp-nvim-lsp',
+      -- Allows extra capabilities provided by blink.cmp
+      'saghen/blink.cmp',
     },
     config = function()
       -- Brief aside: **What is LSP?**
@@ -432,42 +448,55 @@ require('lazy').setup({
             vim.keymap.set(mode, keys, func, { buffer = event.buf, desc = 'LSP: ' .. desc })
           end
 
-          -- Jump to the definition of the word under your cursor.
-          --  This is where a variable was first declared, or where a function is defined, etc.
-          --  To jump back, press <C-t>.
-          map('gd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
+          -- Rename the variable under your cursor.
+          --  Most Language Servers support renaming across files, etc.
+          map('grn', vim.lsp.buf.rename, '[R]e[n]ame')
+
+          -- Execute a code action, usually your cursor needs to be on top of an error
+          -- or a suggestion from your LSP for this to activate.
+          map('gra', vim.lsp.buf.code_action, '[G]oto Code [A]ction', { 'n', 'x' })
 
           -- Find references for the word under your cursor.
-          map('gr', require('telescope.builtin').lsp_references, '[G]oto [R]eferences')
+          map('grr', require('telescope.builtin').lsp_references, '[G]oto [R]eferences')
 
           -- Jump to the implementation of the word under your cursor.
           --  Useful when your language has ways of declaring types without an actual implementation.
-          map('gI', require('telescope.builtin').lsp_implementations, '[G]oto [I]mplementation')
+          map('gri', require('telescope.builtin').lsp_implementations, '[G]oto [I]mplementation')
+
+          -- Jump to the definition of the word under your cursor.
+          --  This is where a variable was first declared, or where a function is defined, etc.
+          --  To jump back, press <C-t>.
+          map('grd', require('telescope.builtin').lsp_definitions, '[G]oto [D]efinition')
+
+          -- WARN: This is not Goto Definition, this is Goto Declaration.
+          --  For example, in C this would take you to the header.
+          map('grD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
+
+          -- Fuzzy find all the symbols in your current document.
+          --  Symbols are things like variables, functions, types, etc.
+          map('gO', require('telescope.builtin').lsp_document_symbols, 'Open Document Symbols')
+
+          -- Fuzzy find all the symbols in your current workspace.
+          --  Similar to document symbols, except searches over your entire project.
+          map('gW', require('telescope.builtin').lsp_dynamic_workspace_symbols, 'Open Workspace Symbols')
 
           -- Jump to the type of the word under your cursor.
           --  Useful when you're not sure what type a variable is and you want to see
           --  the definition of its *type*, not where it was *defined*.
-          map('<leader>D', require('telescope.builtin').lsp_type_definitions, 'Type [D]efinition')
+          map('grt', require('telescope.builtin').lsp_type_definitions, '[G]oto [T]ype Definition')
 
-          -- Fuzzy find all the symbols in your current document.
-          --  Symbols are things like variables, functions, types, etc.
-          map('<leader>ds', require('telescope.builtin').lsp_document_symbols, '[D]ocument [S]ymbols')
-
-          -- Fuzzy find all the symbols in your current workspace.
-          --  Similar to document symbols, except searches over your entire project.
-          map('<leader>ws', require('telescope.builtin').lsp_dynamic_workspace_symbols, '[W]orkspace [S]ymbols')
-
-          -- Rename the variable under your cursor.
-          --  Most Language Servers support renaming across files, etc.
-          map('<leader>rn', vim.lsp.buf.rename, '[R]e[n]ame')
-
-          -- Execute a code action, usually your cursor needs to be on top of an error
-          -- or a suggestion from your LSP for this to activate.
-          map('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction', { 'n', 'x' })
-
-          -- WARN: This is not Goto Definition, this is Goto Declaration.
-          --  For example, in C this would take you to the header.
-          map('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
+          -- This function resolves a difference between neovim nightly (version 0.11) and stable (version 0.10)
+          ---@param client vim.lsp.Client
+          ---@param method vim.lsp.protocol.Method
+          ---@param bufnr? integer some lsp support methods only in specific files
+          ---@return boolean
+          local function client_supports_method(client, method, bufnr)
+            if vim.fn.has 'nvim-0.11' == 1 then
+              return client:supports_method(method, bufnr)
+            else
+              return client.supports_method(method, { bufnr = bufnr })
+            end
+          end
 
           -- The following two autocommands are used to highlight references of the
           -- word under your cursor when your cursor rests there for a little while.
@@ -475,7 +504,7 @@ require('lazy').setup({
           --
           -- When you move your cursor, the highlights will be cleared (the second autocommand).
           local client = vim.lsp.get_client_by_id(event.data.client_id)
-          if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_documentHighlight) then
+          if client and client_supports_method(client, vim.lsp.protocol.Methods.textDocument_documentHighlight, event.buf) then
             local highlight_augroup = vim.api.nvim_create_augroup('kickstart-lsp-highlight', { clear = false })
             vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
               buffer = event.buf,
@@ -502,7 +531,7 @@ require('lazy').setup({
           -- code, if the language server you are using supports them
           --
           -- This may be unwanted, since they displace some of your code
-          if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint) then
+          if client and client_supports_method(client, vim.lsp.protocol.Methods.textDocument_inlayHint, event.buf) then
             map('<leader>th', function()
               vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled { bufnr = event.buf })
             end, '[T]oggle Inlay [H]ints')
@@ -510,22 +539,40 @@ require('lazy').setup({
         end,
       })
 
-      -- Change diagnostic symbols in the sign column (gutter)
-      -- if vim.g.have_nerd_font then
-      --   local signs = { ERROR = '', WARN = '', INFO = '', HINT = '' }
-      --   local diagnostic_signs = {}
-      --   for type, icon in pairs(signs) do
-      --     diagnostic_signs[vim.diagnostic.severity[type]] = icon
-      --   end
-      --   vim.diagnostic.config { signs = { text = diagnostic_signs } }
-      -- end
+      -- Diagnostic Config
+      -- See :help vim.diagnostic.Opts
+      vim.diagnostic.config {
+        severity_sort = true,
+        float = { border = 'rounded', source = 'if_many' },
+        underline = { severity = vim.diagnostic.severity.ERROR },
+        signs = vim.g.have_nerd_font and {
+          text = {
+            [vim.diagnostic.severity.ERROR] = '󰅚 ',
+            [vim.diagnostic.severity.WARN] = '󰀪 ',
+            [vim.diagnostic.severity.INFO] = '󰋽 ',
+            [vim.diagnostic.severity.HINT] = '󰌶 ',
+          },
+        } or {},
+        virtual_text = {
+          source = 'if_many',
+          spacing = 2,
+          format = function(diagnostic)
+            local diagnostic_message = {
+              [vim.diagnostic.severity.ERROR] = diagnostic.message,
+              [vim.diagnostic.severity.WARN] = diagnostic.message,
+              [vim.diagnostic.severity.INFO] = diagnostic.message,
+              [vim.diagnostic.severity.HINT] = diagnostic.message,
+            }
+            return diagnostic_message[diagnostic.severity]
+          end,
+        },
+      }
 
       -- LSP servers and clients are able to communicate to each other what features they support.
       --  By default, Neovim doesn't support everything that is in the LSP specification.
-      --  When you add nvim-cmp, luasnip, etc. Neovim now has *more* capabilities.
-      --  So, we create new capabilities with nvim cmp, and then broadcast that to the servers.
-      local capabilities = vim.lsp.protocol.make_client_capabilities()
-      capabilities = vim.tbl_deep_extend('force', capabilities, require('cmp_nvim_lsp').default_capabilities())
+      --  When you add blink.cmp, luasnip, etc. Neovim now has *more* capabilities.
+      --  So, we create new capabilities with blink.cmp, and then broadcast that to the servers.
+      local capabilities = require('blink.cmp').get_lsp_capabilities()
 
       -- Enable the following language servers
       --  Feel free to add/remove any LSPs that you want here. They will automatically be installed.
@@ -607,6 +654,8 @@ require('lazy').setup({
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
       require('mason-lspconfig').setup {
+        ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
+        automatic_installation = false,
         handlers = {
           function(server_name)
             local server = servers[server_name] or {}
@@ -642,16 +691,14 @@ require('lazy').setup({
         -- have a well standardized coding style. You can add additional
         -- languages here or re-enable it for the disabled ones.
         local disable_filetypes = { c = true, cpp = true }
-        local lsp_format_opt
         if disable_filetypes[vim.bo[bufnr].filetype] then
-          lsp_format_opt = 'never'
+          return nil
         else
-          lsp_format_opt = 'fallback'
+          return {
+            timeout_ms = 500,
+            lsp_format = 'fallback',
+          }
         end
-        return {
-          timeout_ms = 500,
-          lsp_format = lsp_format_opt,
-        }
       end,
       formatters_by_ft = {
         lua = { 'stylua' },
@@ -665,12 +712,14 @@ require('lazy').setup({
   },
 
   { -- Autocompletion
-    'hrsh7th/nvim-cmp',
-    event = 'InsertEnter',
+    'saghen/blink.cmp',
+    event = 'VimEnter',
+    version = '1.*',
     dependencies = {
-      -- Snippet Engine & its associated nvim-cmp source
+      -- Snippet Engine
       {
         'L3MON4D3/LuaSnip',
+        version = '2.*',
         build = (function()
           -- Build Step is needed for regex support in snippets.
           -- This step is not supported in many windows environments.
@@ -691,93 +740,74 @@ require('lazy').setup({
           --   end,
           -- },
         },
+        opts = {},
       },
-      'saadparwaiz1/cmp_luasnip',
-
-      -- Adds other completion capabilities.
-      --  nvim-cmp does not ship with all sources by default. They are split
-      --  into multiple repos for maintenance purposes.
-      'hrsh7th/cmp-nvim-lsp',
-      'hrsh7th/cmp-path',
+      'folke/lazydev.nvim',
     },
-    config = function()
-      -- See `:help cmp`
-      local cmp = require 'cmp'
-      local luasnip = require 'luasnip'
-      luasnip.config.setup {}
-
-      cmp.setup {
-        snippet = {
-          expand = function(args)
-            luasnip.lsp_expand(args.body)
-          end,
-        },
-        completion = { completeopt = 'menu,menuone,noinsert' },
-
-        -- For an understanding of why these mappings were
-        -- chosen, you will need to read `:help ins-completion`
+    --- @module 'blink.cmp'
+    --- @type blink.cmp.Config
+    opts = {
+      keymap = {
+        -- 'default' (recommended) for mappings similar to built-in completions
+        --   <c-y> to accept ([y]es) the completion.
+        --    This will auto-import if your LSP supports it.
+        --    This will expand snippets if the LSP sent a snippet.
+        -- 'super-tab' for tab to accept
+        -- 'enter' for enter to accept
+        -- 'none' for no mappings
+        --
+        -- For an understanding of why the 'default' preset is recommended,
+        -- you will need to read `:help ins-completion`
         --
         -- No, but seriously. Please read `:help ins-completion`, it is really good!
-        mapping = cmp.mapping.preset.insert {
-          -- Select the [n]ext item
-          ['<C-n>'] = cmp.mapping.select_next_item(),
-          -- Select the [p]revious item
-          ['<C-p>'] = cmp.mapping.select_prev_item(),
+        --
+        -- All presets have the following mappings:
+        -- <tab>/<s-tab>: move to right/left of your snippet expansion
+        -- <c-space>: Open menu or open docs if already open
+        -- <c-n>/<c-p> or <up>/<down>: Select next/previous item
+        -- <c-e>: Hide menu
+        -- <c-k>: Toggle signature help
+        --
+        -- See :h blink-cmp-config-keymap for defining your own keymap
+        preset = 'default',
 
-          -- Scroll the documentation window [b]ack / [f]orward
-          ['<C-b>'] = cmp.mapping.scroll_docs(-4),
-          ['<C-f>'] = cmp.mapping.scroll_docs(4),
+        -- For more advanced Luasnip keymaps (e.g. selecting choice nodes, expansion) see:
+        --    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps
+      },
 
-          -- Accept ([y]es) the completion.
-          --  This will auto-import if your LSP supports it.
-          --  This will expand snippets if the LSP sent a snippet.
-          ['<C-y>'] = cmp.mapping.confirm { select = true },
+      appearance = {
+        -- 'mono' (default) for 'Nerd Font Mono' or 'normal' for 'Nerd Font'
+        -- Adjusts spacing to ensure icons are aligned
+        nerd_font_variant = 'mono',
+      },
 
-          -- If you prefer more traditional completion keymaps,
-          -- you can uncomment the following lines
-          --['<CR>'] = cmp.mapping.confirm { select = true },
-          --['<Tab>'] = cmp.mapping.select_next_item(),
-          --['<S-Tab>'] = cmp.mapping.select_prev_item(),
+      completion = {
+        -- By default, you may press `<c-space>` to show the documentation.
+        -- Optionally, set `auto_show = true` to show the documentation after a delay.
+        documentation = { auto_show = false, auto_show_delay_ms = 500 },
+      },
 
-          -- Manually trigger a completion from nvim-cmp.
-          --  Generally you don't need this, because nvim-cmp will display
-          --  completions whenever it has completion options available.
-          ['<C-Space>'] = cmp.mapping.complete {},
-
-          -- Think of <c-l> as moving to the right of your snippet expansion.
-          --  So if you have a snippet that's like:
-          --  function $name($args)
-          --    $body
-          --  end
-          --
-          -- <c-l> will move you to the right of each of the expansion locations.
-          -- <c-h> is similar, except moving you backwards.
-          ['<C-l>'] = cmp.mapping(function()
-            if luasnip.expand_or_locally_jumpable() then
-              luasnip.expand_or_jump()
-            end
-          end, { 'i', 's' }),
-          ['<C-h>'] = cmp.mapping(function()
-            if luasnip.locally_jumpable(-1) then
-              luasnip.jump(-1)
-            end
-          end, { 'i', 's' }),
-
-          -- For more advanced Luasnip keymaps (e.g. selecting choice nodes, expansion) see:
-          --    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps
+      sources = {
+        default = { 'lsp', 'path', 'snippets', 'lazydev' },
+        providers = {
+          lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
         },
-        sources = {
-          {
-            name = 'lazydev',
-            -- set group index to 0 to skip loading LuaLS completions as lazydev recommends it
-            group_index = 0,
-          },
-          { name = 'nvim_lsp' },
-          { name = 'luasnip' },
-          { name = 'path' },
-        },
-      }
-    end,
+      },
+
+      snippets = { preset = 'luasnip' },
+
+      -- Blink.cmp includes an optional, recommended rust fuzzy matcher,
+      -- which automatically downloads a prebuilt binary when enabled.
+      --
+      -- By default, we use the Lua implementation instead, but you may enable
+      -- the rust implementation via `'prefer_rust_with_warning'`
+      --
+      -- See :h blink-cmp-config-fuzzy for more information
+      fuzzy = { implementation = 'lua' },
+
+      -- Shows a signature help window while you type arguments for a function
+      signature = { enabled = true },
+    },
   },
 
   { -- You can easily change to a different colorscheme.
@@ -787,14 +817,18 @@ require('lazy').setup({
     -- If you want to see what colorschemes are already installed, you can use `:Telescope colorscheme`.
     'folke/tokyonight.nvim',
     priority = 1000, -- Make sure to load this before all the other start plugins.
-    init = function()
+    config = function()
+      ---@diagnostic disable-next-line: missing-fields
+      require('tokyonight').setup {
+        styles = {
+          comments = { italic = false }, -- Disable italics in comments
+        },
+      }
+
       -- Load the colorscheme here.
       -- Like many other themes, this one has different styles, and you could load
       -- any other, such as 'tokyonight-storm', 'tokyonight-moon', or 'tokyonight-day'.
-      vim.cmd.colorscheme 'tokyonight'
-
-      -- You can configure highlights by doing something like:
-      vim.cmd.hi 'Comment gui=none'
+      vim.cmd.colorscheme 'tokyonight-night'
     end,
   },
 

--- a/init.lua
+++ b/init.lua
@@ -129,11 +129,11 @@ vim.api.nvim_create_autocmd('TextYankPost', {
 })
 
 vim.api.nvim_create_autocmd('FileType', {
-    pattern = { 'markdown' },
-    callback = function()
-      vim.wo.conceallevel = 2
-    end,
-  })
+  pattern = { 'markdown' },
+  callback = function()
+    vim.wo.conceallevel = 2
+  end,
+})
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 --    See `:help lazy.nvim.txt` or https://github.com/folke/lazy.nvim for more info
@@ -803,7 +803,7 @@ require('lazy').setup({
       -- the rust implementation via `'prefer_rust_with_warning'`
       --
       -- See :h blink-cmp-config-fuzzy for more information
-      fuzzy = { implementation = 'lua' },
+      fuzzy = { implementation = 'prefer_rust_with_warning' },
 
       -- Shows a signature help window while you type arguments for a function
       signature = { enabled = true },

--- a/init.lua
+++ b/init.lua
@@ -94,10 +94,10 @@ vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagn
 vim.keymap.set('t', '<Esc><Esc>', '<C-\\><C-n>', { desc = 'Exit terminal mode' })
 
 -- TIP: Disable arrow keys in normal mode
-vim.keymap.set('n', '<left>', '<cmd>echo "Use h to move!!"<CR>')
-vim.keymap.set('n', '<right>', '<cmd>echo "Use l to move!!"<CR>')
-vim.keymap.set('n', '<up>', '<cmd>echo "Use k to move!!"<CR>')
-vim.keymap.set('n', '<down>', '<cmd>echo "Use j to move!!"<CR>')
+-- vim.keymap.set('n', '<left>', '<cmd>echo "Use h to move!!"<CR>')
+-- vim.keymap.set('n', '<right>', '<cmd>echo "Use l to move!!"<CR>')
+-- vim.keymap.set('n', '<up>', '<cmd>echo "Use k to move!!"<CR>')
+-- vim.keymap.set('n', '<down>', '<cmd>echo "Use j to move!!"<CR>')
 
 -- Keybinds to make split navigation easier.
 --  Use CTRL+<hjkl> to switch between windows
@@ -128,10 +128,19 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   end,
 })
 
+-- -- Show errors and warnings in a floating window
+-- vim.api.nvim_create_autocmd('CursorHold', {
+--   desc = 'Show errors and warnings in a floating window',
+--   callback = function()
+--     vim.diagnostic.open_float(nil, { focusable = true, source = 'if_many' })
+--   end,
+-- })
+
 vim.api.nvim_create_autocmd('FileType', {
   pattern = { 'markdown' },
   callback = function()
     vim.wo.conceallevel = 2
+    vim.cmd 'Pencil'
   end,
 })
 
@@ -574,99 +583,85 @@ require('lazy').setup({
       --  So, we create new capabilities with blink.cmp, and then broadcast that to the servers.
       local capabilities = require('blink.cmp').get_lsp_capabilities()
 
-      -- Enable the following language servers
-      --  Feel free to add/remove any LSPs that you want here. They will automatically be installed.
-      --
-      --  Add any additional override configuration in the following tables. Available keys are:
-      --  - cmd (table): Override the default command used to start the server
-      --  - filetypes (table): Override the default list of associated filetypes for the server
-      --  - capabilities (table): Override fields in capabilities. Can be used to disable certain LSP features.
-      --  - settings (table): Override the default settings passed when initializing the server.
-      --        For example, to see the options for `lua_ls`, you could go to: https://luals.github.io/wiki/settings/
+      -- Enable the following language servers. Configs are merged on top of the
+      -- defaults shipped in nvim-lspconfig's `lsp/<name>.lua`, so we keep cmd /
+      -- root_dir defaults without using the deprecated require('lspconfig')
+      -- framework. See `:help lspconfig-nvim-0.11`.
       local servers = {
-        -- clangd = {},
-        -- gopls = {},
-        -- pyright = {},
-        -- rust_analyzer = {},
-        -- ... etc. See `:help lspconfig-all` for a list of all the pre-configured LSPs
-        --
-        -- Some languages (like typescript) have entire language plugins that can be useful:
-        --    https://github.com/pmizio/typescript-tools.nvim
-        --
-        -- But for many setups, the LSP (`ts_ls`) will work just fine
-        -- ts_ls = {},
-        --
         lua_ls = {
-          -- cmd = { ... },
-          -- filetypes = { ... },
-          -- capabilities = {},
           settings = {
             Lua = {
-              completion = {
-                callSnippet = 'Replace',
-              },
-              -- You can toggle below to ignore Lua_LS's noisy `missing-fields` warnings
-              -- diagnostics = { disable = { 'missing-fields' } },
+              completion = { callSnippet = 'Replace' },
             },
           },
         },
-      }
-      require('lspconfig').ruff.setup {
-        init_options = {
+        terraformls = {
+          cmd = { 'terraform-ls', 'serve' },
+          filetypes = { 'terraform', 'tf', 'terraform-vars' },
+        },
+        tflint = {
+          filetypes = { 'terraform', 'tf' },
+        },
+        ansiblels = {
+          filetypes = { 'yaml.ansible', 'ansible' },
           settings = {
-            -- Ruff language server settings go here
-          },
-        },
-      }
-
-      require('lspconfig').basedpyright.setup {
-        settings = {
-          pyright = {
-            -- Using Ruff's import organizer
-            disableOrganizeImports = true,
-          },
-          python = {
-            analysis = {
-              -- Ignore all files for analysis to exclusively use Ruff for linting
-              ignore = { '*' },
+            ansible = {
+              python = { interpreterPath = 'python3' },
+              ansible = { path = 'ansible' },
+              executionEnvironment = { enabled = false },
+              validation = {
+                enabled = true,
+                lint = { enabled = true, path = 'ansible-lint' },
+              },
             },
           },
         },
+        yamlls = {
+          filetypes = { 'yaml', 'yml' },
+          settings = {
+            yaml = {
+              schemas = {
+                kubernetes = '*.yaml',
+                ['http://json.schemastore.org/ansible-stable-2.9'] = 'playbooks/*.{yml,yaml}',
+                ['http://json.schemastore.org/ansible-playbook'] = '*play*.{yml,yaml}',
+                ['http://json.schemastore.org/github-workflow'] = '.github/workflows/*',
+              },
+              format = { enable = true },
+              validate = true,
+              completion = true,
+              hover = true,
+            },
+          },
+        },
+        ruff = {
+          init_options = { settings = {} },
+        },
+        basedpyright = {
+          settings = {
+            pyright = { disableOrganizeImports = true },
+            python = { analysis = { ignore = { '*' } } },
+          },
+        },
       }
 
-      -- Ensure the servers and tools above are installed
-      --
-      -- To check the current status of installed tools and/or manually install
-      -- other tools, you can run
-      --    :Mason
-      --
-      -- You can press `g?` for help in this menu.
-      --
-      -- `mason` had to be setup earlier: to configure its options see the
-      -- `dependencies` table for `nvim-lspconfig` above.
-      --
-      -- You can add other tools here that you want Mason to install
-      -- for you, so that they are available from within Neovim.
-      local ensure_installed = vim.tbl_keys(servers or {})
+      -- Mason installs servers (above) plus extra tools that are NOT LSPs
+      -- (formatters/linters). Tools live in a separate list so we never hand
+      -- them to vim.lsp.enable.
+      local ensure_installed = vim.tbl_keys(servers)
       vim.list_extend(ensure_installed, {
-        'stylua', -- Used to format Lua code
+        'stylua',
+        'terraform-ls',
+        'tflint',
+        'ansible-language-server',
+        'yaml-language-server',
       })
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
-      require('mason-lspconfig').setup {
-        ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
-        automatic_installation = false,
-        handlers = {
-          function(server_name)
-            local server = servers[server_name] or {}
-            -- This handles overriding only values explicitly passed
-            -- by the server configuration above. Useful when disabling
-            -- certain features of an LSP (for example, turning off formatting for ts_ls)
-            server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-            require('lspconfig')[server_name].setup(server)
-          end,
-        },
-      }
+      for name, cfg in pairs(servers) do
+        cfg.capabilities = vim.tbl_deep_extend('force', {}, capabilities, cfg.capabilities or {})
+        vim.lsp.config(name, cfg)
+        vim.lsp.enable(name)
+      end
     end,
   },
 

--- a/lua/custom/plugins/autopairs.lua
+++ b/lua/custom/plugins/autopairs.lua
@@ -1,0 +1,5 @@
+return {
+  'windwp/nvim-autopairs',
+  event = 'InsertEnter',
+  config = true,
+}

--- a/lua/custom/plugins/autopairs.lua
+++ b/lua/custom/plugins/autopairs.lua
@@ -1,5 +1,0 @@
-return {
-  'windwp/nvim-autopairs',
-  event = 'InsertEnter',
-  config = true,
-}

--- a/lua/custom/plugins/better-escape.lua
+++ b/lua/custom/plugins/better-escape.lua
@@ -1,0 +1,3 @@
+return {
+  'nvim-zh/better-escape.vim',
+}

--- a/lua/custom/plugins/code_companion.lua
+++ b/lua/custom/plugins/code_companion.lua
@@ -1,0 +1,8 @@
+return {
+  'olimorris/codecompanion.nvim',
+  opts = {},
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+    'nvim-treesitter/nvim-treesitter',
+  },
+}

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -1,0 +1,14 @@
+return {
+  {
+    'CopilotC-Nvim/CopilotChat.nvim',
+    dependencies = {
+      { 'github/copilot.vim' }, -- or zbirenbaum/copilot.lua
+      { 'nvim-lua/plenary.nvim', branch = 'master' }, -- for curl, log and async functions
+    },
+    build = 'make tiktoken', -- Only on MacOS or Linux
+    opts = {
+      -- See Configuration section for options
+    },
+    -- See Commands section for default commands if you want to lazy load on them
+  },
+}

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -8,6 +8,15 @@ return {
     build = 'make tiktoken', -- Only on MacOS or Linux
     opts = {
       -- See Configuration section for options
+      prompts = {
+        WriteAtomic = {
+          system_prompt = 'You are a seasoned and experienced Editor. You job is to assist a budding writer and researcher with writing at a higher level.',
+          prompt = 'Please review the following Atomic Note. I want you to analyse it and provide me with feedback. Do not rewrite it. I want to keep my tone and style of writing. I just want to know where I can improve the quality of my writing. A bonus would be to identify any potential biases or gaps in the content which I can focus on adding or improving. But most important is to identify any deficiencies and strengths in the writing. Use the buffer for context: #buffer',
+          mapping = '<leader>apwa',
+          description = 'Copilot: Write Atomic Note',
+        },
+      },
+      -- You can add more prompts here
     },
     -- See Commands section for default commands if you want to lazy load on them
   },

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -15,9 +15,13 @@ return {
           mapping = '<leader>apwa',
           description = 'Copilot: Write Atomic Note',
         },
+        -- You can add more prompts here
       },
-      -- You can add more prompts here
     },
+    config = function(_, opts)
+      require('CopilotChat').setup(opts)
+      vim.api.nvim_set_keymap('n', '<leader>ac', ':CopilotChat<CR>', { noremap = true, silent = true })
+    end,
     -- See Commands section for default commands if you want to lazy load on them
   },
 }

--- a/lua/custom/plugins/cyberdream.lua
+++ b/lua/custom/plugins/cyberdream.lua
@@ -1,0 +1,5 @@
+return {
+  'scottmckendry/cyberdream.nvim',
+  lazy = false,
+  priority = 1000,
+}

--- a/lua/custom/plugins/cyberdream.lua
+++ b/lua/custom/plugins/cyberdream.lua
@@ -1,5 +1,0 @@
-return {
-  'scottmckendry/cyberdream.nvim',
-  lazy = false,
-  priority = 1000,
-}

--- a/lua/custom/plugins/diffview.lua
+++ b/lua/custom/plugins/diffview.lua
@@ -1,0 +1,23 @@
+return {
+  -- Git diff viewer
+  {
+    'sindrets/diffview.nvim',
+    dependencies = { 'nvim-lua/plenary.nvim' },
+    config = function()
+      require('diffview').setup {
+        enhanced_diff_hl = true, -- Highlight word differences within lines
+        view = {
+          default = {
+            layout = 'diff2_horizontal', -- Options: diff2_horizontal, diff2_vertical, diff3_horizontal, diff3_vertical
+          },
+        },
+        file_panel = {
+          win_config = {
+            position = 'left', -- Can be "left", "right", "top", "bottom"
+            width = 35,
+          },
+        },
+      }
+    end,
+  },
+}

--- a/lua/custom/plugins/flutter-tools.lua
+++ b/lua/custom/plugins/flutter-tools.lua
@@ -1,0 +1,9 @@
+return {
+  'nvim-flutter/flutter-tools.nvim',
+  lazy = false,
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+    'stevearc/dressing.nvim', -- optional for vim.ui.select
+  },
+  config = true,
+}

--- a/lua/custom/plugins/golf.lua
+++ b/lua/custom/plugins/golf.lua
@@ -1,0 +1,3 @@
+return {
+  { 'vuciv/golf' },
+}

--- a/lua/custom/plugins/neotest.lua
+++ b/lua/custom/plugins/neotest.lua
@@ -1,0 +1,16 @@
+return {
+  'nvim-neotest/neotest',
+  dependencies = {
+    'nvim-neotest/nvim-nio',
+    'nvim-lua/plenary.nvim',
+    'antoinemadec/FixCursorHold.nvim',
+    'nvim-treesitter/nvim-treesitter',
+  },
+  config = function()
+    require('neotest').setup {
+      adapters = {
+        require 'rustaceanvim.neotest',
+      },
+    }
+  end,
+}

--- a/lua/custom/plugins/noice.lua
+++ b/lua/custom/plugins/noice.lua
@@ -1,0 +1,35 @@
+return {
+  'folke/noice.nvim',
+  event = 'VeryLazy',
+  opts = {
+    -- add any options here
+  },
+  dependencies = {
+    -- if you lazy-load any plugin below, make sure to add proper `module="..."` entries
+    'MunifTanjim/nui.nvim',
+    -- OPTIONAL:
+    --   `nvim-notify` is only needed, if you want to use the notification view.
+    --   If not available, we use `mini` as the fallback
+    'rcarriga/nvim-notify',
+  },
+  config = function(_, opts)
+    require('noice').setup {
+      lsp = {
+        -- override markdown rendering so that **cmp** and other plugins use **Treesitter**
+        override = {
+          ['vim.lsp.util.convert_input_to_markdown_lines'] = true,
+          ['vim.lsp.util.stylize_markdown'] = true,
+          ['cmp.entry.get_documentation'] = true, -- requires hrsh7th/nvim-cmp
+        },
+      },
+      -- you can enable a preset for easier configuration
+      presets = {
+        bottom_search = true, -- use a classic bottom cmdline for search
+        command_palette = true, -- position the cmdline and popupmenu together
+        long_message_to_split = true, -- long messages will be sent to a split
+        inc_rename = false, -- enables an input dialog for inc-rename.nvim
+        lsp_doc_border = false, -- add a border to hover docs and signature help
+      },
+    }
+  end,
+}

--- a/lua/custom/plugins/note2cal.lua
+++ b/lua/custom/plugins/note2cal.lua
@@ -1,0 +1,18 @@
+return {
+  'lfilho/note2cal.nvim',
+  config = function()
+    require('note2cal').setup {
+      debug = false, -- if true, prints a debug message an return early (won't schedule events)
+      calendar_name = 'Calendar', -- the name of the calendar as it appear on Calendar.app
+      highlights = {
+        at_symbol = 'WarningMsg', -- the highlight group for the "@" symbol
+        at_text = 'Number', -- the highlight group for the date-time part
+      },
+      keymaps = {
+        normal = '<Leader>se', -- mnemonic: Schedule Event
+        visual = '<Leader>se', -- mnemonic: Schedule Event
+      },
+    }
+  end,
+  ft = 'markdown',
+}

--- a/lua/custom/plugins/nvim_bacon.lua
+++ b/lua/custom/plugins/nvim_bacon.lua
@@ -1,0 +1,14 @@
+return {
+  -- other plugins
+  {
+    'Canop/nvim-bacon',
+    config = function()
+      require('bacon').setup {
+        quickfix = {
+          enabled = true, -- Enable Quickfix integration
+          event_trigger = true, -- Trigger QuickFixCmdPost after populating Quickfix list
+        },
+      }
+    end,
+  },
+}

--- a/lua/custom/plugins/obsidian.lua
+++ b/lua/custom/plugins/obsidian.lua
@@ -1,0 +1,34 @@
+return {
+  'obsidian-nvim/obsidian.nvim',
+  version = '*', -- recommended, use latest release instead of latest commit
+  lazy = true,
+  ft = 'markdown',
+  -- Replace the above line with this if you only want to load obsidian.nvim for markdown files in your vault:
+  -- event = {
+  --   -- If you want to use the home shortcut '~' here you need to call 'vim.fn.expand'.
+  --   -- E.g. "BufReadPre " .. vim.fn.expand "~" .. "/my-vault/*.md"
+  --   -- refer to `:h file-pattern` for more examples
+  --   "BufReadPre path/to/my-vault/*.md",
+  --   "BufNewFile path/to/my-vault/*.md",
+  -- },
+  dependencies = {
+    -- Required.
+    'nvim-lua/plenary.nvim',
+
+    -- see below for full list of optional dependencies 👇
+  },
+  opts = {
+    workspaces = {
+      {
+        name = 'personal',
+        path = '~/Documents/personal-1',
+      },
+      {
+        name = 'zk',
+        path = '~/zk',
+      },
+    },
+
+    -- see below for full list of options 👇
+  },
+}

--- a/lua/custom/plugins/obsidian.lua
+++ b/lua/custom/plugins/obsidian.lua
@@ -20,12 +20,8 @@ return {
   opts = {
     workspaces = {
       {
-        name = 'personal',
-        path = '~/Documents/personal-1',
-      },
-      {
-        name = 'zk',
-        path = '~/zk',
+        name = 'nts',
+        path = '~/nts',
       },
     },
 

--- a/lua/custom/plugins/obsidian.lua
+++ b/lua/custom/plugins/obsidian.lua
@@ -25,6 +25,8 @@ return {
       },
     },
 
-    -- see below for full list of options 👇
+    checkbox = {
+      order = { ' ', 'x', '~', '!', '>' },
+    },
   },
 }

--- a/lua/custom/plugins/oil.lua
+++ b/lua/custom/plugins/oil.lua
@@ -4,7 +4,12 @@ return {
   'stevearc/oil.nvim',
   ---@module 'oil'
   ---@type oil.SetupOpts
-  opts = {},
+  opts = {
+  view_options = {
+    -- Show hidden files
+    show_hidden = true,
+    },
+  },
   -- Optional dependencies
   dependencies = { { 'echasnovski/mini.icons', opts = {} } },
   -- dependencies = { "nvim-tree/nvim-web-devicons" }, -- use if you prefer nvim-web-devicons

--- a/lua/custom/plugins/oil.lua
+++ b/lua/custom/plugins/oil.lua
@@ -1,0 +1,13 @@
+vim.keymap.set('n', '-', '<CMD>Oil<CR>', { desc = 'Open Oil file explorer' })
+
+return {
+  'stevearc/oil.nvim',
+  ---@module 'oil'
+  ---@type oil.SetupOpts
+  opts = {},
+  -- Optional dependencies
+  dependencies = { { 'echasnovski/mini.icons', opts = {} } },
+  -- dependencies = { "nvim-tree/nvim-web-devicons" }, -- use if you prefer nvim-web-devicons
+  -- Lazy loading is not recommended because it is very tricky to make it work correctly in all situations.
+  lazy = false,
+}

--- a/lua/custom/plugins/pencil.lua
+++ b/lua/custom/plugins/pencil.lua
@@ -1,0 +1,7 @@
+return {
+  'preservim/vim-pencil',
+  init = function()
+    vim.g['pencil#wrapModeDefault'] = 'soft'
+    vim.g['pencil#conceallevel'] = 2
+  end,
+}

--- a/lua/custom/plugins/pomo.lua
+++ b/lua/custom/plugins/pomo.lua
@@ -1,0 +1,29 @@
+return {
+  'epwalsh/pomo.nvim',
+  version = '*', -- Recommended, use latest release instead of latest commit
+  lazy = true,
+  cmd = { 'TimerStart', 'TimerRepeat', 'TimerSession' },
+  dependencies = {
+    -- Optional, but highly recommended if you want to use the "Default" timer
+    'rcarriga/nvim-notify',
+  },
+  opts = {
+    -- See below for full list of options 👇
+    sessions = {
+      norm = {
+        { name = 'Work', duration = '24m30s' },
+        { name = 'Status', duration = '30s' },
+        { name = 'Short Break', duration = '5m' },
+        { name = 'Work', duration = '24m30s' },
+        { name = 'Status', duration = '30s' },
+        { name = 'Short Break', duration = '5m' },
+        { name = 'Work', duration = '24m30s' },
+        { name = 'Status', duration = '30s' },
+        { name = 'Short Break', duration = '5m' },
+        { name = 'Work', duration = '24m30s' },
+        { name = 'Status', duration = '30s' },
+        { name = 'Long Break', duration = '15m' },
+      },
+    },
+  },
+}

--- a/lua/custom/plugins/quickscope.lua
+++ b/lua/custom/plugins/quickscope.lua
@@ -1,0 +1,10 @@
+return {
+  'unblevable/quick-scope',
+  event = { 'VimEnter' }, -- Load plugin on VimEnter event
+  config = function()
+    -- Enable QuickScope highlighting
+    vim.cmd [[
+      let g:qs_highlight_on_keys = ['f', 'F', 't', 'T']
+    ]]
+  end,
+}

--- a/lua/custom/plugins/rustaceanvim.lua
+++ b/lua/custom/plugins/rustaceanvim.lua
@@ -1,0 +1,5 @@
+return {
+  'mrcjkb/rustaceanvim',
+  version = '^5', -- Recommended
+  lazy = false, -- This plugin is already lazy
+}

--- a/lua/custom/plugins/rustaceanvim.lua
+++ b/lua/custom/plugins/rustaceanvim.lua
@@ -1,5 +1,43 @@
 return {
   'mrcjkb/rustaceanvim',
-  version = '^5', -- Recommended
+  version = '^6', -- Recommended
   lazy = false, -- This plugin is already lazy
+  dependencies = { 'nvim-neotest/neotest' },
+  config = function()
+    vim.g.rustaceanvim = {
+      server = {
+        settings = {
+          ['rust-analyzer'] = {
+            check = {
+              command = 'clippy',
+              extra_args = {
+                '--',
+                '-W',
+                'clippy::pedantic',
+                '-W',
+                'clippy::unwrap_used',
+                '-W',
+                'clippy::expect_used',
+                '-W',
+                'clippy::panic',
+                '-W',
+                'clippy::exit',
+                '-W',
+                'clippy::todo',
+                '-W',
+                'clippy::unimplemented',
+                '-W',
+                'clippy::dbg_macro',
+                '-A',
+                'clippy::module_name_repetitions',
+              },
+            },
+            rustfmt = {
+              extraArgs = { '+nightly' },
+            },
+          },
+        },
+      },
+    }
+  end,
 }

--- a/lua/custom/plugins/smear_cursor.lua
+++ b/lua/custom/plugins/smear_cursor.lua
@@ -1,0 +1,4 @@
+return {
+  'sphamba/smear-cursor.nvim',
+  opts = {},
+}

--- a/lua/custom/plugins/snacks.lua
+++ b/lua/custom/plugins/snacks.lua
@@ -1,0 +1,546 @@
+return {
+  'folke/snacks.nvim',
+  priority = 1000,
+  lazy = false,
+  ---@type snacks.Config
+  opts = {
+    toggle = { enabled = true },
+    dim = { enabled = true },
+    lazygit = { enabled = true },
+    bigfile = { enabled = true },
+    dashboard = { enabled = true },
+    explorer = { enabled = true },
+    indent = { enabled = true },
+    input = { enabled = true },
+    notifier = {
+      enabled = true,
+      timeout = 3000,
+    },
+    picker = { enabled = true },
+    quickfile = { enabled = true },
+    scope = { enabled = true },
+    scroll = { enabled = true },
+    statuscolumn = { enabled = true },
+    words = { enabled = true },
+    styles = {
+      notification = {
+        -- wo = { wrap = true } -- Wrap notifications
+      },
+    },
+  },
+  keys = {
+    -- Top Pickers & Explorer
+    {
+      '<leader><space>',
+      function()
+        Snacks.picker.smart()
+      end,
+      desc = 'Smart Find Files',
+    },
+    {
+      '<leader>,',
+      function()
+        Snacks.picker.buffers()
+      end,
+      desc = 'Buffers',
+    },
+    {
+      '<leader>/',
+      function()
+        Snacks.picker.grep()
+      end,
+      desc = 'Grep',
+    },
+    {
+      '<leader>:',
+      function()
+        Snacks.picker.command_history()
+      end,
+      desc = 'Command History',
+    },
+    {
+      '<leader>n',
+      function()
+        Snacks.picker.notifications()
+      end,
+      desc = 'Notification History',
+    },
+    {
+      '<leader>e',
+      function()
+        Snacks.explorer()
+      end,
+      desc = 'File Explorer',
+    },
+    -- find
+    {
+      '<leader>fb',
+      function()
+        Snacks.picker.buffers()
+      end,
+      desc = 'Buffers',
+    },
+    {
+      '<leader>fc',
+      function()
+        Snacks.picker.files { cwd = vim.fn.stdpath 'config' }
+      end,
+      desc = 'Find Config File',
+    },
+    {
+      '<leader>ff',
+      function()
+        Snacks.picker.files()
+      end,
+      desc = 'Find Files',
+    },
+    {
+      '<leader>fg',
+      function()
+        Snacks.picker.git_files()
+      end,
+      desc = 'Find Git Files',
+    },
+    {
+      '<leader>fp',
+      function()
+        Snacks.picker.projects()
+      end,
+      desc = 'Projects',
+    },
+    {
+      '<leader>fr',
+      function()
+        Snacks.picker.recent()
+      end,
+      desc = 'Recent',
+    },
+    -- git
+    {
+      '<leader>gb',
+      function()
+        Snacks.picker.git_branches()
+      end,
+      desc = 'Git Branches',
+    },
+    {
+      '<leader>gl',
+      function()
+        Snacks.picker.git_log()
+      end,
+      desc = 'Git Log',
+    },
+    {
+      '<leader>gL',
+      function()
+        Snacks.picker.git_log_line()
+      end,
+      desc = 'Git Log Line',
+    },
+    {
+      '<leader>gs',
+      function()
+        Snacks.picker.git_status()
+      end,
+      desc = 'Git Status',
+    },
+    {
+      '<leader>gS',
+      function()
+        Snacks.picker.git_stash()
+      end,
+      desc = 'Git Stash',
+    },
+    {
+      '<leader>gd',
+      function()
+        Snacks.picker.git_diff()
+      end,
+      desc = 'Git Diff (Hunks)',
+    },
+    {
+      '<leader>gf',
+      function()
+        Snacks.picker.git_log_file()
+      end,
+      desc = 'Git Log File',
+    },
+    -- Grep
+    {
+      '<leader>sb',
+      function()
+        Snacks.picker.lines()
+      end,
+      desc = 'Buffer Lines',
+    },
+    {
+      '<leader>sB',
+      function()
+        Snacks.picker.grep_buffers()
+      end,
+      desc = 'Grep Open Buffers',
+    },
+    {
+      '<leader>sg',
+      function()
+        Snacks.picker.grep()
+      end,
+      desc = 'Grep',
+    },
+    {
+      '<leader>sw',
+      function()
+        Snacks.picker.grep_word()
+      end,
+      desc = 'Visual selection or word',
+      mode = { 'n', 'x' },
+    },
+    -- search
+    {
+      '<leader>s"',
+      function()
+        Snacks.picker.registers()
+      end,
+      desc = 'Registers',
+    },
+    {
+      '<leader>s/',
+      function()
+        Snacks.picker.search_history()
+      end,
+      desc = 'Search History',
+    },
+    {
+      '<leader>sa',
+      function()
+        Snacks.picker.autocmds()
+      end,
+      desc = 'Autocmds',
+    },
+    {
+      '<leader>sb',
+      function()
+        Snacks.picker.lines()
+      end,
+      desc = 'Buffer Lines',
+    },
+    {
+      '<leader>sc',
+      function()
+        Snacks.picker.command_history()
+      end,
+      desc = 'Command History',
+    },
+    {
+      '<leader>sC',
+      function()
+        Snacks.picker.commands()
+      end,
+      desc = 'Commands',
+    },
+    {
+      '<leader>sd',
+      function()
+        Snacks.picker.diagnostics()
+      end,
+      desc = 'Diagnostics',
+    },
+    {
+      '<leader>sD',
+      function()
+        Snacks.picker.diagnostics_buffer()
+      end,
+      desc = 'Buffer Diagnostics',
+    },
+    {
+      '<leader>sh',
+      function()
+        Snacks.picker.help()
+      end,
+      desc = 'Help Pages',
+    },
+    {
+      '<leader>sH',
+      function()
+        Snacks.picker.highlights()
+      end,
+      desc = 'Highlights',
+    },
+    {
+      '<leader>si',
+      function()
+        Snacks.picker.icons()
+      end,
+      desc = 'Icons',
+    },
+    {
+      '<leader>sj',
+      function()
+        Snacks.picker.jumps()
+      end,
+      desc = 'Jumps',
+    },
+    {
+      '<leader>sk',
+      function()
+        Snacks.picker.keymaps()
+      end,
+      desc = 'Keymaps',
+    },
+    {
+      '<leader>sl',
+      function()
+        Snacks.picker.loclist()
+      end,
+      desc = 'Location List',
+    },
+    {
+      '<leader>sm',
+      function()
+        Snacks.picker.marks()
+      end,
+      desc = 'Marks',
+    },
+    {
+      '<leader>sM',
+      function()
+        Snacks.picker.man()
+      end,
+      desc = 'Man Pages',
+    },
+    {
+      '<leader>sp',
+      function()
+        Snacks.picker.lazy()
+      end,
+      desc = 'Search for Plugin Spec',
+    },
+    {
+      '<leader>sq',
+      function()
+        Snacks.picker.qflist()
+      end,
+      desc = 'Quickfix List',
+    },
+    {
+      '<leader>sR',
+      function()
+        Snacks.picker.resume()
+      end,
+      desc = 'Resume',
+    },
+    {
+      '<leader>su',
+      function()
+        Snacks.picker.undo()
+      end,
+      desc = 'Undo History',
+    },
+    {
+      '<leader>uC',
+      function()
+        Snacks.picker.colorschemes()
+      end,
+      desc = 'Colorschemes',
+    },
+    -- LSP
+    {
+      'gd',
+      function()
+        Snacks.picker.lsp_definitions()
+      end,
+      desc = 'Goto Definition',
+    },
+    {
+      'gD',
+      function()
+        Snacks.picker.lsp_declarations()
+      end,
+      desc = 'Goto Declaration',
+    },
+    {
+      'gr',
+      function()
+        Snacks.picker.lsp_references()
+      end,
+      nowait = true,
+      desc = 'References',
+    },
+    {
+      'gI',
+      function()
+        Snacks.picker.lsp_implementations()
+      end,
+      desc = 'Goto Implementation',
+    },
+    {
+      'gy',
+      function()
+        Snacks.picker.lsp_type_definitions()
+      end,
+      desc = 'Goto T[y]pe Definition',
+    },
+    {
+      '<leader>ss',
+      function()
+        Snacks.picker.lsp_symbols()
+      end,
+      desc = 'LSP Symbols',
+    },
+    {
+      '<leader>sS',
+      function()
+        Snacks.picker.lsp_workspace_symbols()
+      end,
+      desc = 'LSP Workspace Symbols',
+    },
+    -- Other
+    {
+      '<leader>z',
+      function()
+        Snacks.zen()
+      end,
+      desc = 'Toggle Zen Mode',
+    },
+    {
+      '<leader>Z',
+      function()
+        Snacks.zen.zoom()
+      end,
+      desc = 'Toggle Zoom',
+    },
+    {
+      '<leader>.',
+      function()
+        Snacks.scratch()
+      end,
+      desc = 'Toggle Scratch Buffer',
+    },
+    {
+      '<leader>S',
+      function()
+        Snacks.scratch.select()
+      end,
+      desc = 'Select Scratch Buffer',
+    },
+    {
+      '<leader>n',
+      function()
+        Snacks.notifier.show_history()
+      end,
+      desc = 'Notification History',
+    },
+    {
+      '<leader>bd',
+      function()
+        Snacks.bufdelete()
+      end,
+      desc = 'Delete Buffer',
+    },
+    {
+      '<leader>cR',
+      function()
+        Snacks.rename.rename_file()
+      end,
+      desc = 'Rename File',
+    },
+    {
+      '<leader>gB',
+      function()
+        Snacks.gitbrowse()
+      end,
+      desc = 'Git Browse',
+      mode = { 'n', 'v' },
+    },
+    {
+      '<leader>gg',
+      function()
+        Snacks.lazygit()
+      end,
+      desc = 'Lazygit',
+    },
+    {
+      '<leader>un',
+      function()
+        Snacks.notifier.hide()
+      end,
+      desc = 'Dismiss All Notifications',
+    },
+    {
+      '<c-/>',
+      function()
+        Snacks.terminal()
+      end,
+      desc = 'Toggle Terminal',
+    },
+    {
+      '<c-_>',
+      function()
+        Snacks.terminal()
+      end,
+      desc = 'which_key_ignore',
+    },
+    {
+      ']]',
+      function()
+        Snacks.words.jump(vim.v.count1)
+      end,
+      desc = 'Next Reference',
+      mode = { 'n', 't' },
+    },
+    {
+      '[[',
+      function()
+        Snacks.words.jump(-vim.v.count1)
+      end,
+      desc = 'Prev Reference',
+      mode = { 'n', 't' },
+    },
+    {
+      '<leader>N',
+      desc = 'Neovim News',
+      function()
+        Snacks.win {
+          file = vim.api.nvim_get_runtime_file('doc/news.txt', false)[1],
+          width = 0.6,
+          height = 0.6,
+          wo = {
+            spell = false,
+            wrap = false,
+            signcolumn = 'yes',
+            statuscolumn = ' ',
+            conceallevel = 3,
+          },
+        }
+      end,
+    },
+  },
+  init = function()
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'VeryLazy',
+      callback = function()
+        -- Setup some globals for debugging (lazy-loaded)
+        _G.dd = function(...)
+          Snacks.debug.inspect(...)
+        end
+        _G.bt = function()
+          Snacks.debug.backtrace()
+        end
+        vim.print = _G.dd -- Override print to use snacks for `:=` command
+
+        -- Create some toggle mappings
+        Snacks.toggle.option('spell', { name = 'Spelling' }):map '<leader>us'
+        Snacks.toggle.option('wrap', { name = 'Wrap' }):map '<leader>uw'
+        Snacks.toggle.option('relativenumber', { name = 'Relative Number' }):map '<leader>uL'
+        Snacks.toggle.diagnostics():map '<leader>ud'
+        Snacks.toggle.line_number():map '<leader>ul'
+        Snacks.toggle.option('conceallevel', { off = 0, on = vim.o.conceallevel > 0 and vim.o.conceallevel or 2 }):map '<leader>uc'
+        Snacks.toggle.treesitter():map '<leader>uT'
+        Snacks.toggle.option('background', { off = 'light', on = 'dark', name = 'Dark Background' }):map '<leader>ub'
+        Snacks.toggle.inlay_hints():map '<leader>uh'
+        Snacks.toggle.indent():map '<leader>ug'
+        Snacks.toggle.dim():map '<leader>uD'
+      end,
+    })
+  end,
+}

--- a/lua/custom/plugins/telescope-frecency.lua
+++ b/lua/custom/plugins/telescope-frecency.lua
@@ -1,0 +1,8 @@
+return {
+  'nvim-telescope/telescope-frecency.nvim',
+  -- install the latest stable version
+  version = '*',
+  config = function()
+    require('telescope').load_extension 'frecency'
+  end,
+}

--- a/lua/custom/plugins/tiny-glimmer.lua
+++ b/lua/custom/plugins/tiny-glimmer.lua
@@ -1,0 +1,139 @@
+return {
+  'rachartier/tiny-glimmer.nvim',
+  event = 'VeryLazy',
+  priority = 10,
+  opts = {
+    enabled = true,
+    disable_warnings = true,
+    refresh_interval_ms = 8,
+    overwrite = {
+      auto_map = true,
+      yank = {
+        enabled = true,
+        default_animation = 'fade',
+      },
+      search = {
+        enabled = false,
+        default_animation = 'pulse',
+        next_mapping = 'n',
+        prev_mapping = 'N',
+      },
+      paste = {
+        enabled = true,
+        default_animation = 'reverse_fade',
+        paste_mapping = 'p',
+        Paste_mapping = 'P',
+      },
+      undo = {
+        enabled = false,
+        default_animation = {
+          name = 'fade',
+          settings = {
+            from_color = 'DiffDelete',
+            max_duration = 500,
+            min_duration = 500,
+          },
+        },
+        undo_mapping = 'u',
+      },
+      redo = {
+        enabled = false,
+        default_animation = {
+          name = 'fade',
+          settings = {
+            from_color = 'DiffAdd',
+            max_duration = 500,
+            min_duration = 500,
+          },
+        },
+        redo_mapping = '<c-r>',
+      },
+    },
+    support = {
+      substitute = {
+        enabled = false,
+        default_animation = 'fade',
+      },
+    },
+    presets = {
+      pulsar = {
+        enabled = false,
+        on_events = { 'CursorMoved', 'CmdlineEnter', 'WinEnter' },
+        default_animation = {
+          name = 'fade',
+          settings = {
+            max_duration = 1000,
+            min_duration = 1000,
+            from_color = 'DiffDelete',
+            to_color = 'Normal',
+          },
+        },
+      },
+    },
+    transparency_color = nil,
+    animations = {
+      fade = {
+        max_duration = 400,
+        min_duration = 300,
+        easing = 'outQuad',
+        chars_for_max_duration = 10,
+        from_color = 'Visual',
+        to_color = 'Normal',
+      },
+      reverse_fade = {
+        max_duration = 380,
+        min_duration = 300,
+        easing = 'outBack',
+        chars_for_max_duration = 10,
+        from_color = 'Visual',
+        to_color = 'Normal',
+      },
+      bounce = {
+        max_duration = 500,
+        min_duration = 400,
+        chars_for_max_duration = 20,
+        oscillation_count = 1,
+        from_color = 'Visual',
+        to_color = 'Normal',
+      },
+      left_to_right = {
+        max_duration = 350,
+        min_duration = 350,
+        min_progress = 0.85,
+        chars_for_max_duration = 25,
+        lingering_time = 50,
+        from_color = 'Visual',
+        to_color = 'Normal',
+      },
+      pulse = {
+        max_duration = 600,
+        min_duration = 400,
+        chars_for_max_duration = 15,
+        pulse_count = 2,
+        intensity = 1.2,
+        from_color = 'Visual',
+        to_color = 'Normal',
+      },
+      rainbow = {
+        max_duration = 600,
+        min_duration = 350,
+        chars_for_max_duration = 20,
+      },
+      custom = {
+        max_duration = 350,
+        chars_for_max_duration = 40,
+        color = 'Visual', -- You can replace this with a highlight group or hex
+        effect = function(self, progress)
+          return self.settings.color, progress
+        end,
+      },
+      hijack_ft_disabled = {
+        'alpha',
+        'snacks_dashboard',
+      },
+    },
+    virt_text = {
+      priority = 2048,
+    },
+  },
+}

--- a/lua/custom/plugins/tokyonight.lua
+++ b/lua/custom/plugins/tokyonight.lua
@@ -1,0 +1,6 @@
+return {
+  'folke/tokyonight.nvim',
+  lazy = false,
+  priority = 1000,
+  opts = {},
+}

--- a/lua/custom/plugins/tranparent.lua
+++ b/lua/custom/plugins/tranparent.lua
@@ -1,0 +1,5 @@
+return {
+  'tribela/transparent.nvim',
+  event = 'VimEnter',
+  config = true,
+}

--- a/lua/custom/plugins/trouble.lua
+++ b/lua/custom/plugins/trouble.lua
@@ -1,0 +1,37 @@
+return {
+  'folke/trouble.nvim',
+  opts = {}, -- for default options, refer to the configuration section for custom setup.
+  cmd = 'Trouble',
+  keys = {
+    {
+      '<leader>xx',
+      '<cmd>Trouble diagnostics toggle<cr>',
+      desc = 'Diagnostics (Trouble)',
+    },
+    {
+      '<leader>xX',
+      '<cmd>Trouble diagnostics toggle filter.buf=0<cr>',
+      desc = 'Buffer Diagnostics (Trouble)',
+    },
+    {
+      '<leader>cs',
+      '<cmd>Trouble symbols toggle focus=false<cr>',
+      desc = 'Symbols (Trouble)',
+    },
+    {
+      '<leader>cl',
+      '<cmd>Trouble lsp toggle focus=false win.position=right<cr>',
+      desc = 'LSP Definitions / references / ... (Trouble)',
+    },
+    {
+      '<leader>xL',
+      '<cmd>Trouble loclist toggle<cr>',
+      desc = 'Location List (Trouble)',
+    },
+    {
+      '<leader>xQ',
+      '<cmd>Trouble qflist toggle<cr>',
+      desc = 'Quickfix List (Trouble)',
+    },
+  },
+}

--- a/lua/custom/plugins/trouble.lua
+++ b/lua/custom/plugins/trouble.lua
@@ -4,9 +4,19 @@ return {
   cmd = 'Trouble',
   keys = {
     {
-      '<leader>xx',
+      '<leader>xd',
       '<cmd>Trouble diagnostics toggle<cr>',
       desc = 'Diagnostics (Trouble)',
+    },
+    {
+      '<leader>xl',
+      function()
+        require('trouble').toggle {
+          mode = 'diagnostics',
+          win = { position = 'right', type = 'split', size = 75 },
+        }
+      end,
+      desc = 'Toggle Trouble diagnostics sidebar',
     },
     {
       '<leader>xX',

--- a/lua/custom/plugins/typr.lua
+++ b/lua/custom/plugins/typr.lua
@@ -1,0 +1,6 @@
+return {
+  'nvzone/typr',
+  dependencies = 'nvzone/volt',
+  opts = {},
+  cmd = { 'Typr', 'TyprStats' },
+}

--- a/lua/custom/plugins/unimpaired.lua
+++ b/lua/custom/plugins/unimpaired.lua
@@ -1,0 +1,7 @@
+return {
+  'tummetott/unimpaired.nvim',
+  event = 'VeryLazy',
+  opts = {
+    -- add options here if you wish to override the default settings
+  },
+}

--- a/lua/custom/plugins/wezterm-move.lua
+++ b/lua/custom/plugins/wezterm-move.lua
@@ -1,0 +1,29 @@
+return {
+  'letieu/wezterm-move.nvim',
+  keys = { -- Lazy loading, don't need call setup() function
+    {
+      '<C-h>',
+      function()
+        require('wezterm-move').move 'h'
+      end,
+    },
+    {
+      '<C-j>',
+      function()
+        require('wezterm-move').move 'j'
+      end,
+    },
+    {
+      '<C-k>',
+      function()
+        require('wezterm-move').move 'k'
+      end,
+    },
+    {
+      '<C-l>',
+      function()
+        require('wezterm-move').move 'l'
+      end,
+    },
+  },
+}

--- a/lua/kickstart/plugins/autopairs.lua
+++ b/lua/kickstart/plugins/autopairs.lua
@@ -4,13 +4,5 @@
 return {
   'windwp/nvim-autopairs',
   event = 'InsertEnter',
-  -- Optional dependency
-  dependencies = { 'hrsh7th/nvim-cmp' },
-  config = function()
-    require('nvim-autopairs').setup {}
-    -- If you want to automatically add `(` after selecting a function or method
-    local cmp_autopairs = require 'nvim-autopairs.completion.cmp'
-    local cmp = require 'cmp'
-    cmp.event:on('confirm_done', cmp_autopairs.on_confirm_done())
-  end,
+  opts = {},
 }

--- a/lua/kickstart/plugins/gitsigns.lua
+++ b/lua/kickstart/plugins/gitsigns.lua
@@ -44,7 +44,7 @@ return {
         map('n', '<leader>hs', gitsigns.stage_hunk, { desc = 'git [s]tage hunk' })
         map('n', '<leader>hr', gitsigns.reset_hunk, { desc = 'git [r]eset hunk' })
         map('n', '<leader>hS', gitsigns.stage_buffer, { desc = 'git [S]tage buffer' })
-        map('n', '<leader>hu', gitsigns.undo_stage_hunk, { desc = 'git [u]ndo stage hunk' })
+        map('n', '<leader>hu', gitsigns.stage_hunk, { desc = 'git [u]ndo stage hunk' })
         map('n', '<leader>hR', gitsigns.reset_buffer, { desc = 'git [R]eset buffer' })
         map('n', '<leader>hp', gitsigns.preview_hunk, { desc = 'git [p]review hunk' })
         map('n', '<leader>hb', gitsigns.blame_line, { desc = 'git [b]lame line' })
@@ -54,7 +54,7 @@ return {
         end, { desc = 'git [D]iff against last commit' })
         -- Toggles
         map('n', '<leader>tb', gitsigns.toggle_current_line_blame, { desc = '[T]oggle git show [b]lame line' })
-        map('n', '<leader>tD', gitsigns.toggle_deleted, { desc = '[T]oggle git show [D]eleted' })
+        map('n', '<leader>tD', gitsigns.preview_hunk_inline, { desc = '[T]oggle git show [D]eleted' })
       end,
     },
   },

--- a/lua/kickstart/plugins/indent_line.lua
+++ b/lua/kickstart/plugins/indent_line.lua
@@ -1,9 +1,0 @@
-return {
-  { -- Add indentation guides even on blank lines
-    'lukas-reineke/indent-blankline.nvim',
-    -- Enable `lukas-reineke/indent-blankline.nvim`
-    -- See `:help ibl`
-    main = 'ibl',
-    opts = {},
-  },
-}


### PR DESCRIPTION
## Summary

Neovim was crashing on startup with a stack trace ending at `init.lua:664`, and two LSP clients (`stylua`, `Copilot`) were dying every session. This PR fixes the crash and the spurious `stylua` LSP client, and bundles accumulated plugin work that had been lingering in the working tree.

### What was broken

- `require('lspconfig').<server>.setup()` is deprecated on nvim 0.11 and will be removed in nvim-lspconfig v3.0.0. The framework's `__index` was already raising on `.ruff` / `.basedpyright`, producing the stack trace.
- `nvim-lspconfig` now ships a community `lsp/stylua.lua` definition. The old `mason-lspconfig` `handlers` block was iterating over every mason-installed package whose name matched a known lspconfig server — so the **stylua formatter** was being launched as an LSP server with `--lsp`, exiting 2 every startup.
- The third error (`Copilot: Process exited with status 243`) is an npm cache permission issue on the local machine (`EACCES` on `~/.npm/_npx/...`). Not a config bug — see verification notes below.

### What this PR does

**Commit 1 — `fix(lsp)`** (init.lua only)
- Replaces the deprecated `require('lspconfig').xxx.setup(...)` pattern with native 0.11 API: `vim.lsp.config(name, cfg)` + `vim.lsp.enable(name)`.
- Folds `ruff` and `basedpyright` into the main `servers` table so they get the blink.cmp capability merge and Mason auto-install like everything else.
- Drops `mason-lspconfig.setup { handlers = ... }` entirely. With handlers gone, only names explicitly handed to `vim.lsp.enable` are ever launched — `stylua` cannot be mis-started as an LSP again. It stays in `mason-tool-installer`'s list as a formatter for conform.nvim.

**Commit 2 — `chore(plugins)`** (everything else that was sitting in the working tree)
- New: `code_companion`, `golf`, `neotest` (rustaceanvim adapter), `nvim-bacon`, `vim-pencil`, `quickscope`.
- Modified: `rustaceanvim` → `^6` with clippy/rustfmt config + neotest dep; `obsidian` checkbox order; `trouble` keymaps reworked (`<leader>xx` → `<leader>xd`, add `<leader>xl` sidebar toggle).
- Deleted: `cyberdream` (tokyonight is the active colorscheme now).

## Test plan

- [ ] **Out-of-band first:** `sudo chown -R 501:20 ~/.npm` — fixes the Copilot 243 error (root-owned files in `~/.npm/_npx/`). This is system state, not in the diff.
- [ ] `nvim` from `$HOME` — no stack trace, no deprecation warning, no `Client stylua quit` notification.
- [ ] Open a `.lua` file → `:LspInfo` shows `lua_ls` attached and **no `stylua` client**.
- [ ] Open a `.py` file → `:LspInfo` shows both `ruff` and `basedpyright`.
- [ ] Open `.tf`, ansible `.yml`, plain `.yaml` → corresponding server attaches.
- [ ] `<leader>f` on a Lua file still formats via stylua (through conform.nvim).
- [ ] `:Mason` lists `ruff`, `basedpyright`, `stylua`, `lua-language-server`, `terraform-ls`, `tflint`, `ansible-language-server`, `yaml-language-server` all installed.
- [ ] `:checkhealth lsp` clean.
- [ ] After the chown, `:CopilotChat` opens without spawning a 243 exit, and `~/.local/state/nvim/lsp.log` shows no new `stylua --lsp` or `EACCES` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)