### PR TITLE
chore: add discussions to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Help
+    url: https://github.com/nvim-lua/kickstart.nvim/discussions/categories/q-a
+    about: Ask the community for help
+
+  - name: Ideas
+    url: https://github.com/nvim-lua/kickstart.nvim/discussions/categories/ideas
+    about: Share ideas for new features


### PR DESCRIPTION
Now that GitHub discussions have been enabled (see https://github.com/nvim-lua/kickstart.nvim/issues/2026), add links in the issue template to help redirect help/feature requests from the bug tracker.

Obviously feel free to suggest better names and descriptions!
