### PR TITLE
Telescope: Hint for searching through symlinked neovim configurations

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -575,6 +575,7 @@ do
   )
 
   -- Shortcut for searching your Neovim configuration files
+  --  See `:help telescope.builtin.find_files()` for symlinked neovim configurations
   vim.keymap.set('n', '<leader>sn', function() builtin.find_files { cwd = vim.fn.stdpath 'config' } end, { desc = '[S]earch [N]eovim files' })
 end
 


### PR DESCRIPTION
`builtin.find_files {..., follow = true}` required


Adds a comment to the `<leader>sn` keymap that guides users to `:help telescope.builtin.find_files()` if searching Neovim configuration files behaves unexpectedly (empty list).
