### PR TITLE
chore(init.lua): clarify section comments

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -86,7 +86,7 @@ P.S. You can delete this when you're done too. It's your config now! :)
 
 -- ============================================================
 -- SECTION 1: OPTIONS
--- Core Neovim settings, leaders, options, basic keymaps, basic autocmds
+-- Core Neovim settings, leaders, options
 -- ============================================================
 do
   -- Enable faster startup by caching compiled Lua modules
@@ -175,7 +175,7 @@ end
 
 -- ============================================================
 -- SECTION 2: KEYMAPS
--- basic keymaps
+-- basic keymaps, basic autocmds
 -- ============================================================
 do
   -- [[ Basic Keymaps ]]


### PR DESCRIPTION
Now that there is section 2 for keymaps. It doesn't need to be in section 1.

Two more things:

- You have an autocommand under keymaps.
- Keeping comments like `-- [[ Basic Keymaps ]]` feels a bit redundant. I know you are keeping parity with kickstart-modular.nvim