### PR TITLE
fix: deprecated `on_yank` command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -245,11 +245,11 @@ do
 
   -- Highlight when yanking (copying) text
   --  Try it with `yap` in normal mode
-  --  See `:help vim.hl.on_yank()`
+  --  See `:help vim.hl.hl_op()`
   vim.api.nvim_create_autocmd('TextYankPost', {
     desc = 'Highlight when yanking (copying) text',
     group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
-    callback = function() vim.hl.on_yank() end,
+    callback = function() vim.hl.hl_op() end,
   })
 end
 


### PR DESCRIPTION
**vim.hl.on_yank** is deprecated and the feature will be removed in Nvim 0.14.

It's possible to check through the command: `:checkhealth vim.deprecated` 
```
- ⚠️ WARNING vim.hl.on_yank is deprecated. Feature will be removed in Nvim 0.14
  - ADVICE:
    - use vim.hl.hl_op instead.
```