### PR TITLE
refactor(conform): notify on error

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -784,7 +784,6 @@ do
   -- [[ Formatting ]]
   vim.pack.add { gh 'stevearc/conform.nvim' }
   require('conform').setup {
-    notify_on_error = false,
     format_on_save = function(bufnr)
       -- You can specify filetypes to autoformat on save here:
       local enabled_filetypes = {


### PR DESCRIPTION
In my opinion, we should notify on error by default. This is also the default configuration for conform.

In my usage with conform, I haven't felt that the error noise is an issue. Sometimes it's nice for me when I'm blazing through stuff, I miss the LSP diagnostics, but then when I write I get an error from conform formatter because my syntax tree is broken.
