### PR TITLE
gitsigns: use `buf` keymap option on Neovim 0.12.1+, fallback to buffer on older versions

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -364,7 +364,12 @@ do
     on_attach = function(bufnr)
       local function map(mode, l, r, opts)
         opts = opts or {}
-        opts.buffer = bufnr
+        -- opts.buf requires Neovim 0.12.1+; older versions use opts.buffer
+        if vim.version.ge and vim.version.ge(vim.version(), '0.12.1') then
+          opts.buf = bufnr
+        else
+          opts.buffer = bufnr
+        end
         vim.keymap.set(mode, l, r, opts)
       end
 

--- a/init.lua
+++ b/init.lua
@@ -362,43 +362,49 @@ do
     },
     -- gitsigns.nvim's recommended keymaps:
     on_attach = function(bufnr)
+      local function map(mode, l, r, opts)
+        opts = opts or {}
+        opts.buffer = bufnr
+        vim.keymap.set(mode, l, r, opts)
+      end
+
       -- Navigation
-      vim.keymap.set('n', ']c', function()
+      map('n', ']c', function()
         if vim.wo.diff then
           vim.cmd.normal { ']c', bang = true }
         else
           gitsigns.nav_hunk 'next'
         end
-      end, { desc = 'Jump to next git [c]hange', buf = bufnr })
+      end, { desc = 'Jump to next git [c]hange' })
 
-      vim.keymap.set('n', '[c', function()
+      map('n', '[c', function()
         if vim.wo.diff then
           vim.cmd.normal { '[c', bang = true }
         else
           gitsigns.nav_hunk 'prev'
         end
-      end, { desc = 'Jump to previous git [c]hange', buf = bufnr })
+      end, { desc = 'Jump to previous git [c]hange' })
 
       -- Visual mode actions
-      vim.keymap.set('v', '<leader>hs', function() gitsigns.stage_hunk { vim.fn.line '.', vim.fn.line 'v' } end, { desc = 'git [s]tage hunk', buf = bufnr })
-      vim.keymap.set('v', '<leader>hr', function() gitsigns.reset_hunk { vim.fn.line '.', vim.fn.line 'v' } end, { desc = 'git [r]eset hunk', buf = bufnr })
+      map('v', '<leader>hs', function() gitsigns.stage_hunk { vim.fn.line '.', vim.fn.line 'v' } end, { desc = 'git [s]tage hunk' })
+      map('v', '<leader>hr', function() gitsigns.reset_hunk { vim.fn.line '.', vim.fn.line 'v' } end, { desc = 'git [r]eset hunk' })
       -- Normal mode actions
-      vim.keymap.set('n', '<leader>hs', gitsigns.stage_hunk, { desc = 'git [s]tage hunk', buf = bufnr })
-      vim.keymap.set('n', '<leader>hr', gitsigns.reset_hunk, { desc = 'git [r]eset hunk', buf = bufnr })
-      vim.keymap.set('n', '<leader>hS', gitsigns.stage_buffer, { desc = 'git [S]tage buffer', buf = bufnr })
-      vim.keymap.set('n', '<leader>hR', gitsigns.reset_buffer, { desc = 'git [R]eset buffer', buf = bufnr })
-      vim.keymap.set('n', '<leader>hp', gitsigns.preview_hunk, { desc = 'git [p]review hunk', buf = bufnr })
-      vim.keymap.set('n', '<leader>hi', gitsigns.preview_hunk_inline, { desc = 'git preview hunk [i]nline', buf = bufnr })
-      vim.keymap.set('n', '<leader>hb', function() gitsigns.blame_line { full = true } end, { desc = 'git [b]lame line', buf = bufnr })
-      vim.keymap.set('n', '<leader>hd', gitsigns.diffthis, { desc = 'git [d]iff against index', buf = bufnr })
-      vim.keymap.set('n', '<leader>hD', function() gitsigns.diffthis '~' end, { desc = 'git [D]iff against last commit', buf = bufnr })
-      vim.keymap.set('n', '<leader>hQ', function() gitsigns.setqflist 'all' end, { desc = 'git hunk [Q]uickfix list (all files in repo)', buf = bufnr })
-      vim.keymap.set('n', '<leader>hq', gitsigns.setqflist, { desc = 'git hunk [q]uickfix list (all changes in this file)', buf = bufnr })
+      map('n', '<leader>hs', gitsigns.stage_hunk, { desc = 'git [s]tage hunk' })
+      map('n', '<leader>hr', gitsigns.reset_hunk, { desc = 'git [r]eset hunk' })
+      map('n', '<leader>hS', gitsigns.stage_buffer, { desc = 'git [S]tage buffer' })
+      map('n', '<leader>hR', gitsigns.reset_buffer, { desc = 'git [R]eset buffer' })
+      map('n', '<leader>hp', gitsigns.preview_hunk, { desc = 'git [p]review hunk' })
+      map('n', '<leader>hi', gitsigns.preview_hunk_inline, { desc = 'git preview hunk [i]nline' })
+      map('n', '<leader>hb', function() gitsigns.blame_line { full = true } end, { desc = 'git [b]lame line' })
+      map('n', '<leader>hd', gitsigns.diffthis, { desc = 'git [d]iff against index' })
+      map('n', '<leader>hD', function() gitsigns.diffthis '~' end, { desc = 'git [D]iff against last commit' })
+      map('n', '<leader>hQ', function() gitsigns.setqflist 'all' end, { desc = 'git hunk [Q]uickfix list (all files in repo)' })
+      map('n', '<leader>hq', gitsigns.setqflist, { desc = 'git hunk [q]uickfix list (all changes in this file)' })
       -- Toggles
-      vim.keymap.set('n', '<leader>tb', gitsigns.toggle_current_line_blame, { desc = '[T]oggle git show [b]lame line', buf = bufnr })
-      vim.keymap.set('n', '<leader>tw', gitsigns.toggle_word_diff, { desc = '[T]oggle git intra-line [w]ord diff', buf = bufnr })
+      map('n', '<leader>tb', gitsigns.toggle_current_line_blame, { desc = '[T]oggle git show [b]lame line' })
+      map('n', '<leader>tw', gitsigns.toggle_word_diff, { desc = '[T]oggle git intra-line [w]ord diff' })
       -- Text object
-      vim.keymap.set({ 'o', 'x' }, 'ih', gitsigns.select_hunk, { desc = 'text object [i]nside [h]unk', buf = bufnr })
+      map({ 'o', 'x' }, 'ih', gitsigns.select_hunk, { desc = 'text object [i]nside [h]unk' })
     end,
   }
 


### PR DESCRIPTION
The recent move from keymap.set buffer to buf broke neovim on ubuntu 25.10 with:
```
vim/keymap.lua:0: invalid key: buf
```
nvim on ubuntu 25.10 is: v0.12.0-dev
So recent enough but not quite 0.12.0 release - it's an earlier pre-release snapshot, so it breaks.
I think we could make an effort to keep the support of such a version, hence this PR.
There are 2 commits:
```
    gitsigns re-introduce back the map helper so that buf/buffer can be runtime selected
```
and:
```
    gitsigns: use `buf` keymap option on Neovim 0.12.1+
    
    Follows the upstream rename of `buffer` to `buf` (neovim/neovim#38360,
    first shipped in v0.12.0); `buffer` is soft-deprecated, removal
    planned in v0.15. Fall back to `buffer` on older Neovim.
    
    The 0.12.1 floor (not 0.12.0) avoids distro snapshot builds like
    Ubuntu 25.10 `0.12.0~ubuntu1` (git snapshot d62bbe24cb), which reports
    `0.12.0-dev` but predates the `buf` support and rejects it with
    `invalid key: buf`.
```
