### PR TITLE
Check if the buffer is valid when trying to attach TS

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -954,11 +954,12 @@ do
   ---@param buf integer
   ---@param language string
   local function treesitter_try_attach(buf, language)
+    -- Check if a parser exists and load it
+    if not vim.treesitter.language.add(language) then return end
+
     -- Check if the buffer is valid (might not be after install completes)
     if not vim.api.nvim_buf_is_valid(buf) then return end
 
-    -- Check if a parser exists and load it
-    if not vim.treesitter.language.add(language) then return end
     -- Enable syntax highlighting and other treesitter features
     vim.treesitter.start(buf, language)
 

--- a/init.lua
+++ b/init.lua
@@ -954,6 +954,9 @@ do
   ---@param buf integer
   ---@param language string
   local function treesitter_try_attach(buf, language)
+    -- Check if the buffer is valid (might not be after install completes)
+    if not vim.api.nvim_buf_is_valid(buf) then return end
+
     -- Check if a parser exists and load it
     if not vim.treesitter.language.add(language) then return end
     -- Enable syntax highlighting and other treesitter features


### PR DESCRIPTION
I found a small race condition in the TS install path, where a closed buffer would pop an error after the buffer isntalled. You can repro by running the below script after deleting your zig queries/parsers from the state directory and running `nvim -u repro.lua`.

```lua
dofile(vim.fn.expand("/path/to/kickstart.nvim/init.lua"))

vim.fn.mkdir("/tmp/ts-repro", "p")
vim.fn.writefile({ "const x = 1;" }, "/tmp/ts-repro/sample.zig")

vim.schedule(function()
	vim.cmd("edit /tmp/ts-repro/sample.zig")
	vim.cmd("bwipeout!")
end)
```

You should expect to see
```
vim.schedule callback: /opt/nvim/share/nvim/runtime/lua/vim/treesitter.lua:443:
 Invalid buffer id: 1   
```

This PR fixes that bug by checking if the buffer is still valid before attempting to attach TS.